### PR TITLE
Add library category

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Markus Sattler
 maintainer=Markus Sattler 
 sentence=WebSockets for Arduino (Server + Client)
 paragraph=
+category=Communication
 url=https://github.com/Links2004/arduinoWebSockets
 architectures=*


### PR DESCRIPTION
Add library category as documented [here](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format).

This prevents a Warning in the new Arduino 1.6.6.