### PR TITLE
add possibilty to define subprotocol of websockets client

### DIFF
--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -27,7 +27,7 @@
 
 #include <Arduino.h>
 
-//#define DEBUG_WEBSOCKETS(...) Serial1.printf( __VA_ARGS__ )
+//#define DEBUG_WEBSOCKETS(...) Serial.printf( __VA_ARGS__ )
 
 #ifndef DEBUG_WEBSOCKETS
 #define DEBUG_WEBSOCKETS(...)

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -72,14 +72,14 @@ void WebSocketsClient::begin(String host, uint16_t port, String url, String Prot
 }
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
-void WebSocketsClient::beginSSL(const char *host, uint16_t port, const char * url, const char * fingerprint) {
-    begin(host, port, url);
+void WebSocketsClient::beginSSL(const char *host, uint16_t port, const char * url, const char * fingerprint, const char * Protocol) {
+    begin(host, port, url, Protocol);
     _client.isSSL = true;
     _fingerprint = fingerprint;
 }
 
-void WebSocketsClient::beginSSL(String host, uint16_t port, String url, String fingerprint) {
-    beginSSL(host.c_str(), port, url.c_str(), fingerprint.c_str());
+void WebSocketsClient::beginSSL(String host, uint16_t port, String url, String fingerprint, String Protocol) {
+    beginSSL(host.c_str(), port, url.c_str(), fingerprint.c_str(), Protocol.c_str());
 }
 #endif
 

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -37,7 +37,7 @@ WebSocketsClient::~WebSocketsClient() {
 /**
  * calles to init the Websockets server
  */
-void WebSocketsClient::begin(const char *host, uint16_t port, const char * url) {
+void WebSocketsClient::begin(const char *host, uint16_t port, const char * url, const char * Protocol) {
     _host = host;
     _port = port;
     _fingerprint = "";
@@ -55,7 +55,7 @@ void WebSocketsClient::begin(const char *host, uint16_t port, const char * url) 
     _client.cIsWebsocket = true;
     _client.cKey = "";
     _client.cAccept = "";
-    _client.cProtocol = "";
+    _client.cProtocol = Protocol;
     _client.cExtensions = "";
     _client.cVersion = 0;
 
@@ -67,8 +67,8 @@ void WebSocketsClient::begin(const char *host, uint16_t port, const char * url) 
 #endif
 }
 
-void WebSocketsClient::begin(String host, uint16_t port, String url) {
-    begin(host.c_str(), port, url.c_str());
+void WebSocketsClient::begin(String host, uint16_t port, String url, String Protocol) {
+    begin(host.c_str(), port, url.c_str(), Protocol.c_str());
 }
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
@@ -366,7 +366,7 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
                         "Connection: Upgrade\r\n"
                         "User-Agent: arduino-WebSocket-Client\r\n"
                         "Sec-WebSocket-Version: 13\r\n"
-                        "Sec-WebSocket-Protocol: arduino\r\n"
+                        "Sec-WebSocket-Protocol:" + client->cProtocol +"\r\n"
                         "Sec-WebSocket-Key: " + client->cKey + "\r\n";
 
     if(client->cExtensions.length() > 0) {

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -36,8 +36,8 @@ class WebSocketsClient: private WebSockets {
         WebSocketsClient(void);
         ~WebSocketsClient(void);
 
-        void begin(const char *host, uint16_t port, const char * url = "/");
-        void begin(String host, uint16_t port, String url = "/");
+        void begin(const char *host, uint16_t port, const char * url = "/", const char * Protocol = "arduino");
+        void begin(String host, uint16_t port, String url = "/", String Protocol = "arduino");
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
         void beginSSL(const char *host, uint16_t port, const char * url = "/", const char * = "");

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -40,8 +40,8 @@ class WebSocketsClient: private WebSockets {
         void begin(String host, uint16_t port, String url = "/", String Protocol = "arduino");
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
-        void beginSSL(const char *host, uint16_t port, const char * url = "/", const char * = "");
-        void beginSSL(String host, uint16_t port, String url = "/", String fingerprint = "");
+        void beginSSL(const char *host, uint16_t port, const char * url = "/", const char * = "", const char * Protocol = "arduino");
+        void beginSSL(String host, uint16_t port, String url = "/", String fingerprint = "", String Protocol = "arduino");
 #endif
 
         void loop(void);


### PR DESCRIPTION
Add the possibility to define subprotocol in websocket client. If not defined "arduino" is still used.

Not an experient coder, but I believe the changes make it  backwards compatible with code already written.