### PR TITLE
Adjustments to headers during client handshake.

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -393,8 +393,9 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 
     String handshake =  "GET " + client->cUrl + " HTTP/1.1\r\n"
                         "Host: " + _host + ":" + _port + "\r\n"
-                        "Upgrade: websocket\r\n"
                         "Connection: Upgrade\r\n"
+                        "Upgrade: websocket\r\n"
+                        "Origin: file://\r\n"
                         "User-Agent: arduino-WebSocket-Client\r\n"
                         "Sec-WebSocket-Version: 13\r\n"
                         "Sec-WebSocket-Key: " + client->cKey + "\r\n";

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -392,7 +392,7 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 #endif
 
     String handshake =  "GET " + client->cUrl + " HTTP/1.1\r\n"
-                        "Host: " + _host + "\r\n"
+                        "Host: " + _host + ":" + _port + "\r\n"
                         "Upgrade: websocket\r\n"
                         "Connection: Upgrade\r\n"
                         "User-Agent: arduino-WebSocket-Client\r\n"
@@ -620,6 +620,3 @@ void WebSocketsClient::asyncConnect() {
 }
 
 #endif
-
-
-


### PR DESCRIPTION
Added the port number to Host, which is required when the port is not 80 or 443.
Also added Origin.  Without it some WebSocket Servers will fail the handshake.  This should probably be user configurable.