### PR TITLE
Compatibility for broken servers and additional authentication option instead of just basic

### DIFF
--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -181,6 +181,7 @@ typedef struct {
         WSMessageHeader_t cWsHeaderDecode;
 
         String base64Authorization; ///< Base64 encoded Auth request
+        String plainAuthorization; ///< Base64 encoded Auth request
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)
         String cHttpLine;   ///< HTTP header lines

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -448,7 +448,7 @@ void WebSocketsClient::handleHeader(WSclient_t * client, String * headerLine) {
             String headerValue = headerLine->substring(headerLine->indexOf(':') + 2);
 
             if(headerName.equalsIgnoreCase("Connection")) {
-                if(headerValue.indexOf("upgrade") >= 0) {
+                if(headerValue.equalsIgnoreCase("upgrade")) {
                     client->cIsUpgrade = true;
                 }
             } else if(headerName.equalsIgnoreCase("Upgrade")) {

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -62,6 +62,7 @@ void WebSocketsClient::begin(const char *host, uint16_t port, const char * url, 
     _client.cExtensions = "";
     _client.cVersion = 0;
     _client.base64Authorization = "";
+    _client.plainAuthorization = "";
 
 #ifdef ESP8266
     randomSeed(RANDOM_REG32);
@@ -228,7 +229,8 @@ void WebSocketsClient::setAuthorization(const char * user, const char * password
  */
 void WebSocketsClient::setAuthorization(const char * auth) {
     if(auth) {
-        _client.base64Authorization = auth;
+        //_client.base64Authorization = auth;
+        _client.plainAuthorization = auth;
     }
 }
 
@@ -400,7 +402,7 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
                         "Sec-WebSocket-Key: " + client->cKey + "\r\n";
 
     if(client->cProtocol.length() > 0) {
-        handshake += "Sec-WebSocket-Protocol: " + client->cProtocol + "\r\n";
+       handshake += "Sec-WebSocket-Protocol: " + client->cProtocol + "\r\n";
     }
 
     if(client->cExtensions.length() > 0) {
@@ -409,6 +411,10 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 
     if(client->base64Authorization.length() > 0) {
         handshake += "Authorization: Basic " + client->base64Authorization + "\r\n";
+    }
+
+    if(client->plainAuthorization.length() > 0) {
+        handshake += "Authorization: " + client->plainAuthorization + "\r\n";
     }
 
     handshake += "\r\n";
@@ -442,7 +448,7 @@ void WebSocketsClient::handleHeader(WSclient_t * client, String * headerLine) {
             String headerValue = headerLine->substring(headerLine->indexOf(':') + 2);
 
             if(headerName.equalsIgnoreCase("Connection")) {
-                if(headerValue.indexOf("Upgrade") >= 0) {
+                if(headerValue.indexOf("upgrade") >= 0) {
                     client->cIsUpgrade = true;
                 }
             } else if(headerName.equalsIgnoreCase("Upgrade")) {


### PR DESCRIPTION
Hi Markus,
Firstly thanks for this great library. I have made two changes and was hoping you could merge them into your library:

1. I adopted the change you had already made for the "Upgrade" header to the "Connection" header. I looked at the RFC and Upgrade with upper case should be the expected value, but there seems to be a lot of "broken" servers out there (for instance everything based on TomCat) that send a lower case upgrade. the equalsIgnoreCase should work with both and make your library work with all servers. 

2. I changed the behavior of the setAuthorization(const char * auth) function. In the original you just took the passed value and appended it unmodified to the Authorization header, but it still had the BASIC in front of it. Therefore it would still only allow basic authentication. With the little change I made you could for instance pass "Bearer xxxxAuthTokenxxxx" to enable token based authentication on a lot of IoT platforms. If people really want to pass a pre-made Basic auth header then they can just use "BASIC xxxxxxxBasicAuthValuexxxxx" to achieve what the library currently does. 

Thank you for considering the changes and thanks again.

Cheers,
Thorsten

PS. :Viele Grüße, habe gerade gesehen das "Germany" deine Location ist... ;-) 