### PR TITLE
RFC 6455 4.2.1.4 case sensitivity fix

### DIFF
--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -590,7 +590,8 @@ void WebSocketsServer::handleHeader(WSclient_t * client, String * headerLine) {
             String headerValue = headerLine->substring(headerLine->indexOf(':') + 2);
 
             if(headerName.equalsIgnoreCase("Connection")) {
-                if(headerValue.equalsIgnoreCase("Upgrade")) {
+                headerValue.toLowerCase();
+            	if(headerValue.indexOf("upgrade") >= 0) {
                     client->cIsUpgrade = true;
                 }
             } else if(headerName.equalsIgnoreCase("Upgrade")) {


### PR DESCRIPTION
This is a case sensitivity fix for the Connection header Upgrade value to make this part meet the requirement of IETF websocket RFC 6455 4.2.1.4: "A |Connection| header field that includes the token "Upgrade", treated as an ASCII case-insensitive value."