### PR TITLE
WEBSOCKETS_NETWORK_TYPE exteral definition

### DIFF
--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -52,12 +52,14 @@
 // max size of the WS Message Header
 #define WEBSOCKETS_MAX_HEADER_SIZE  (14)
 
+#if !defined(WEBSOCKETS_NETWORK_TYPE) 
 // select Network type based
 #if defined(ESP8266) || defined(ESP31B)
 #define WEBSOCKETS_NETWORK_TYPE NETWORK_ESP8266
 //#define WEBSOCKETS_NETWORK_TYPE NETWORK_ESP8266_ASYNC
 #else
 #define WEBSOCKETS_NETWORK_TYPE NETWORK_W5100
+#endif
 #endif
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)


### PR DESCRIPTION
Making possible to define WEBSOCKETS_NETWORK_TYPE as a compile parameter.