### PR TITLE
Change inheritance of WebSocketServer

### DIFF
--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -33,7 +33,7 @@
 
 
 
-class WebSocketsServer: public WebSockets {
+class WebSocketsServer: protected WebSockets {
 public:
 
 #ifdef __AVR__

--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -33,7 +33,7 @@
 
 
 
-class WebSocketsServer: private WebSockets {
+class WebSocketsServer: public WebSockets {
 public:
 
 #ifdef __AVR__


### PR DESCRIPTION
This allows classes inheriting from it to call sendFrame with custom
arguments.
This is useful for example to implement continuation frames support, like in this [example](https://gist.github.com/nerochiaro/6d5ad350ad6c094c21b6cd02c48c67e3)