### PR TITLE
Extra headers (including removal of "Origin") and SockJS+STOMP example

### DIFF
--- a/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
+++ b/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
@@ -137,7 +137,7 @@ void setup() {
 
     // connect to websocket
     webSocket.begin(ws_host, ws_port, socketUrl);
-    webSocket.setExtraHeaders(""); // remove "Origin: file://" header because it breaks the connection with Spring's default websocket config
+    webSocket.setExtraHeaders(); // remove "Origin: file://" header because it breaks the connection with Spring's default websocket config
 //    webSocket.setExtraHeaders("foo: I am so funny\r\nbar: not"); // some headers, in case you feel funny
     webSocket.onEvent(webSocketEvent);
 }

--- a/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
+++ b/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
@@ -1,0 +1,155 @@
+/*
+ * WebSocketClientSockJsAndStomp.ino
+ * 
+ * Example for connecting and maintining a connection with a SockJS+STOMP websocket connection.
+ * In this example we connect to a Spring application (see https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html).
+ *
+ *  Created on: 18.07.2017
+ *  Author: Martin Becker <mgbckr>, contact: becker@informatik.uni-wuerzburg.de
+ */
+
+// CONSTANTS AND MACROS
+
+#define DEBUG_WEBSOCKETS
+#define DEBUG_WEBSOCKETS(...) Serial.printf( __VA_ARGS__ )
+
+#define WEBSOCKETS_NETWORK_TYPE NETWORK_ESP8266
+#define WEBSOCKETS_HEADERS_NO_ORIGIN
+
+#define USE_SERIAL Serial
+
+
+// LIBRARIES
+
+#include <ESP8266WiFi.h>
+#include <WebSocketsClient.h>
+
+
+// SETTINGS
+
+const char* wlan_ssid             = "yourssid";
+const char* wlan_password         = "password";
+
+const char* ws_host               = "the.host.com";
+const int   ws_port               = 80;
+
+// base URL for SockJS (websocket) connection
+// The complete URL will look something like this(cf. http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-36): 
+// ws://<ws_host>:<ws_port>/<ws_baseurl>/<3digits>/<randomstring>/websocket
+// For the default config of Spring's SockJS/STOMP support the default base URL is "/socketentry/".
+const char* ws_baseurl            = "/socketentry/"; // don't forget leading and trailing "/" !!!
+
+
+// VARIABLES
+
+WebSocketsClient webSocket;
+
+
+// FUNCTIONS
+
+void webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
+
+    switch(type) {
+        case WStype_DISCONNECTED:
+            USE_SERIAL.printf("[WSc] Disconnected!\n");
+            break;
+        case WStype_CONNECTED:
+            {
+                USE_SERIAL.printf("[WSc] Connected to url: %s\n",  payload);
+            }
+            break;
+        case WStype_TEXT: {
+
+            // #####################
+            // handle STOMP protocol
+            // #####################
+
+            String text = (char*) payload; 
+        
+            USE_SERIAL.printf("[WSc] get text: %s\n", payload);
+
+            if (payload[0] == 'h') {
+              
+              USE_SERIAL.println("Heartbeat!");
+              
+            } else if (payload[0] == 'o') {
+
+              // on open connection
+              char *msg = "[\"CONNECT\\naccept-version:1.1,1.0\\nheart-beat:10000,10000\\n\\n\\u0000\"]";
+              webSocket.sendTXT(msg);
+              
+            } else if (text.startsWith("a[\"CONNECTED")) {
+
+              // subscribe to some channels
+              
+              char *msg = "[\"SUBSCRIBE\\nid:sub-0\\ndestination:/user/queue/messages\\n\\n\\u0000\"]";
+              webSocket.sendTXT(msg);
+              delay(1000);
+
+              // and send a message
+
+              msg = "[\"SEND\\ndestination:/app/message\\ncontent-length:33\\n\\n{\\\"user\\\":\\\"esp\\\",\\\"message\\\":\\\"Hello!\\\"}\\u0000\"]";
+              webSocket.sendTXT(msg);
+              delay(1000);
+            }
+
+            break;
+        } 
+        case WStype_BIN:
+            USE_SERIAL.printf("[WSc] get binary length: %u\n", length);
+            hexdump(payload, length);
+
+            // send data to server
+            // webSocket.sendBIN(payload, length);
+            break;
+    }
+
+}
+
+void setup() {
+
+    // setup serial
+
+    // USE_SERIAL.begin(921600);
+    USE_SERIAL.begin(115200);
+
+//    USE_SERIAL.setDebugOutput(true);
+
+    USE_SERIAL.println();
+
+    for(uint8_t t = 4; t > 0; t--) {
+        USE_SERIAL.printf("[SETUP] BOOT WAIT %d...\n", t);
+        USE_SERIAL.flush();
+        delay(1000);
+    }
+
+    // connect to WiFi
+
+    USE_SERIAL.print("Logging into WLAN: "); Serial.print(wlan_ssid); Serial.print(" ...");
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(wlan_ssid, wlan_password);
+    
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(500);
+      USE_SERIAL.print(".");
+    }
+    USE_SERIAL.println(" success.");
+    USE_SERIAL.print("IP: "); USE_SERIAL.println(WiFi.localIP());
+    
+    // #####################
+    // create socket url according to SockJS protocol (cf. http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-36)
+    // #####################
+    String socketUrl = ws_baseurl;
+    socketUrl += random(0,999);
+    socketUrl += "/";
+    socketUrl += random(0,999999); // should be a random string, but this works (see )
+    socketUrl += "/websocket";
+
+    // connect to websocket
+    webSocket.begin(ws_host, ws_port, socketUrl);
+    webSocket.onEvent(webSocketEvent);
+}
+
+void loop() {
+    webSocket.loop();
+}

--- a/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
+++ b/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
@@ -1,12 +1,12 @@
 /*
- * WebSocketClientSockJsAndStomp.ino
- * 
- * Example for connecting and maintining a connection with a SockJS+STOMP websocket connection.
- * In this example we connect to a Spring application (see https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html).
- *
- *  Created on: 18.07.2017
- *  Author: Martin Becker <mgbckr>, Contact: becker@informatik.uni-wuerzburg.de
- */
+    WebSocketClientSockJsAndStomp.ino
+
+    Example for connecting and maintining a connection with a SockJS+STOMP websocket connection.
+    In this example we connect to a Spring application (see https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html).
+
+    Created on: 18.07.2017
+    Author: Martin Becker <mgbckr>, Contact: becker@informatik.uni-wuerzburg.de
+*/
 
 // PRE
 
@@ -28,7 +28,7 @@ const char* ws_host               = "the.host.net";
 const int   ws_port               = 80;
 
 // base URL for SockJS (websocket) connection
-// The complete URL will look something like this(cf. http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-36): 
+// The complete URL will look something like this(cf. http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-36):
 // ws://<ws_host>:<ws_port>/<ws_baseurl>/<3digits>/<randomstring>/websocket
 // For the default config of Spring's SockJS/STOMP support the default base URL is "/socketentry/".
 const char* ws_baseurl            = "/socketentry/"; // don't forget leading and trailing "/" !!!
@@ -43,7 +43,7 @@ WebSocketsClient webSocket;
 
 void webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
 
-    switch(type) {
+    switch (type) {
         case WStype_DISCONNECTED:
             USE_SERIAL.printf("[WSc] Disconnected!\n");
             break;
@@ -52,43 +52,43 @@ void webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
                 USE_SERIAL.printf("[WSc] Connected to url: %s\n",  payload);
             }
             break;
-        case WStype_TEXT: {
+        case WStype_TEXT: 
+            {
+                // #####################
+                // handle STOMP protocol
+                // #####################
 
-            // #####################
-            // handle STOMP protocol
-            // #####################
+                String text = (char*) payload;
 
-            String text = (char*) payload; 
-        
-            USE_SERIAL.printf("[WSc] get text: %s\n", payload);
+                USE_SERIAL.printf("[WSc] get text: %s\n", payload);
 
-            if (payload[0] == 'h') {
-              
-              USE_SERIAL.println("Heartbeat!");
-              
-            } else if (payload[0] == 'o') {
+                if (payload[0] == 'h') {
 
-              // on open connection
-              char *msg = "[\"CONNECT\\naccept-version:1.1,1.0\\nheart-beat:10000,10000\\n\\n\\u0000\"]";
-              webSocket.sendTXT(msg);
-              
-            } else if (text.startsWith("a[\"CONNECTED")) {
+                    USE_SERIAL.println("Heartbeat!");
 
-              // subscribe to some channels
-              
-              char *msg = "[\"SUBSCRIBE\\nid:sub-0\\ndestination:/user/queue/messages\\n\\n\\u0000\"]";
-              webSocket.sendTXT(msg);
-              delay(1000);
+                } else if (payload[0] == 'o') {
 
-              // and send a message
+                    // on open connection
+                    char *msg = "[\"CONNECT\\naccept-version:1.1,1.0\\nheart-beat:10000,10000\\n\\n\\u0000\"]";
+                    webSocket.sendTXT(msg);
 
-              msg = "[\"SEND\\ndestination:/app/message\\n\\n{\\\"user\\\":\\\"esp\\\",\\\"message\\\":\\\"Hello!\\\"}\\u0000\"]";
-              webSocket.sendTXT(msg);
-              delay(1000);
+                } else if (text.startsWith("a[\"CONNECTED")) {
+
+                    // subscribe to some channels
+
+                    char *msg = "[\"SUBSCRIBE\\nid:sub-0\\ndestination:/user/queue/messages\\n\\n\\u0000\"]";
+                    webSocket.sendTXT(msg);
+                    delay(1000);
+
+                    // and send a message
+
+                    msg = "[\"SEND\\ndestination:/app/message\\n\\n{\\\"user\\\":\\\"esp\\\",\\\"message\\\":\\\"Hello!\\\"}\\u0000\"]";
+                    webSocket.sendTXT(msg);
+                    delay(1000);
+                }
+
+                break;
             }
-
-            break;
-        } 
         case WStype_BIN:
             USE_SERIAL.printf("[WSc] get binary length: %u\n", length);
             hexdump(payload, length);
@@ -107,7 +107,7 @@ void setup() {
     // USE_SERIAL.begin(921600);
     USE_SERIAL.begin(115200);
 
-//    USE_SERIAL.setDebugOutput(true);
+    //    USE_SERIAL.setDebugOutput(true);
 
     USE_SERIAL.println();
 
@@ -117,28 +117,28 @@ void setup() {
     USE_SERIAL.print("Logging into WLAN: "); Serial.print(wlan_ssid); Serial.print(" ...");
     WiFi.mode(WIFI_STA);
     WiFi.begin(wlan_ssid, wlan_password);
-    
+
     while (WiFi.status() != WL_CONNECTED) {
-      delay(500);
-      USE_SERIAL.print(".");
+        delay(500);
+        USE_SERIAL.print(".");
     }
     USE_SERIAL.println(" success.");
     USE_SERIAL.print("IP: "); USE_SERIAL.println(WiFi.localIP());
 
-    
+
     // #####################
     // create socket url according to SockJS protocol (cf. http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-36)
     // #####################
     String socketUrl = ws_baseurl;
-    socketUrl += random(0,999);
+    socketUrl += random(0, 999);
     socketUrl += "/";
-    socketUrl += random(0,999999); // should be a random string, but this works (see )
+    socketUrl += random(0, 999999); // should be a random string, but this works (see )
     socketUrl += "/websocket";
 
     // connect to websocket
     webSocket.begin(ws_host, ws_port, socketUrl);
     webSocket.setExtraHeaders(); // remove "Origin: file://" header because it breaks the connection with Spring's default websocket config
-//    webSocket.setExtraHeaders("foo: I am so funny\r\nbar: not"); // some headers, in case you feel funny
+    //    webSocket.setExtraHeaders("foo: I am so funny\r\nbar: not"); // some headers, in case you feel funny
     webSocket.onEvent(webSocketEvent);
 }
 

--- a/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
+++ b/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
@@ -5,16 +5,10 @@
  * In this example we connect to a Spring application (see https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html).
  *
  *  Created on: 18.07.2017
- *  Author: Martin Becker <mgbckr>, contact: becker@informatik.uni-wuerzburg.de
+ *  Author: Martin Becker <mgbckr>, Contact: becker@informatik.uni-wuerzburg.de
  */
 
-// CONSTANTS AND MACROS
-
-#define DEBUG_WEBSOCKETS
-#define DEBUG_WEBSOCKETS(...) Serial.printf( __VA_ARGS__ )
-
-#define WEBSOCKETS_NETWORK_TYPE NETWORK_ESP8266
-#define WEBSOCKETS_HEADERS_NO_ORIGIN
+// PRE
 
 #define USE_SERIAL Serial
 
@@ -28,9 +22,9 @@
 // SETTINGS
 
 const char* wlan_ssid             = "yourssid";
-const char* wlan_password         = "password";
+const char* wlan_password         = "somepassword";
 
-const char* ws_host               = "the.host.com";
+const char* ws_host               = "the.host.net";
 const int   ws_port               = 80;
 
 // base URL for SockJS (websocket) connection
@@ -117,11 +111,6 @@ void setup() {
 
     USE_SERIAL.println();
 
-    for(uint8_t t = 4; t > 0; t--) {
-        USE_SERIAL.printf("[SETUP] BOOT WAIT %d...\n", t);
-        USE_SERIAL.flush();
-        delay(1000);
-    }
 
     // connect to WiFi
 
@@ -135,6 +124,7 @@ void setup() {
     }
     USE_SERIAL.println(" success.");
     USE_SERIAL.print("IP: "); USE_SERIAL.println(WiFi.localIP());
+
     
     // #####################
     // create socket url according to SockJS protocol (cf. http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-36)
@@ -147,6 +137,8 @@ void setup() {
 
     // connect to websocket
     webSocket.begin(ws_host, ws_port, socketUrl);
+    webSocket.setExtraHeaders(""); // remove "Origin: file://" header because it breaks the connection with Spring's default websocket config
+//    webSocket.setExtraHeaders("foo: I am so funny\r\nbar: not"); // some headers, in case you feel funny
     webSocket.onEvent(webSocketEvent);
 }
 

--- a/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
+++ b/examples/WebSocketClientSockJsAndStomp/WebSocketClientSockJsAndStomp.ino
@@ -82,7 +82,7 @@ void webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
 
               // and send a message
 
-              msg = "[\"SEND\\ndestination:/app/message\\ncontent-length:33\\n\\n{\\\"user\\\":\\\"esp\\\",\\\"message\\\":\\\"Hello!\\\"}\\u0000\"]";
+              msg = "[\"SEND\\ndestination:/app/message\\n\\n{\\\"user\\\":\\\"esp\\\",\\\"message\\\":\\\"Hello!\\\"}\\u0000\"]";
               webSocket.sendTXT(msg);
               delay(1000);
             }

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -226,6 +226,8 @@ typedef struct {
         String base64Authorization; ///< Base64 encoded Auth request
         String plainAuthorization; ///< Base64 encoded Auth request
 
+        String extraHeaders;
+
         bool cHttpHeadersValid; ///< non-websocket http header validity indicator
         size_t cMandatoryHeadersCount; ///< non-websocket mandatory http headers present count
 

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -479,8 +479,12 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 		handshake += WEBSOCKETS_STRING("Connection: keep-alive\r\n");
 	}
 
-	handshake += WEBSOCKETS_STRING("Origin: file://\r\n"
-			"User-Agent: arduino-WebSocket-Client\r\n");
+#ifndef WEBSOCKET_HEADERS_NO_ORIGIN
+	// add origin header if requested
+	handshake += WEBSOCKETS_STRING("Origin: file://\r\n");
+#endif
+	
+	handshake += WEBSOCKETS_STRING("User-Agent: arduino-WebSocket-Client\r\n");
 
 	if(client->base64Authorization.length() > 0) {
 		handshake += WEBSOCKETS_STRING("Authorization: Basic ");

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -29,7 +29,7 @@
 WebSocketsClient::WebSocketsClient() {
     _cbEvent = NULL;
     _client.num = 0;
-    _client.extraHeaders = "Origin: file://";
+    _client.extraHeaders = WEBSOCKETS_STRING("Origin: file://");
 }
 
 WebSocketsClient::~WebSocketsClient() {
@@ -490,8 +490,10 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 	}
 
 	// add extra headers; by default this includes "Origin: file://"
-	handshake += client->extraHeaders + NEW_LINE;
-	
+	if (client->extraHeaders) {
+		handshake += client->extraHeaders + NEW_LINE;
+	}	
+
 	handshake += WEBSOCKETS_STRING("User-Agent: arduino-WebSocket-Client\r\n");
 
 	if(client->base64Authorization.length() > 0) {

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -29,6 +29,7 @@
 WebSocketsClient::WebSocketsClient() {
     _cbEvent = NULL;
     _client.num = 0;
+    _client.extraHeaders = "Origin: file://";
 }
 
 WebSocketsClient::~WebSocketsClient() {
@@ -274,6 +275,15 @@ void WebSocketsClient::setAuthorization(const char * auth) {
     }
 }
 
+/**
+ * set extra headers for the http request;
+ * separate headers by "\r\n"
+ * @param extraHeaders const char * extraHeaders
+ */
+void WebSocketsClient::setExtraHeaders(const char * extraHeaders) {
+    _client.extraHeaders = extraHeaders;
+}
+
 //#################################################################################
 //#################################################################################
 //#################################################################################
@@ -479,10 +489,8 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 		handshake += WEBSOCKETS_STRING("Connection: keep-alive\r\n");
 	}
 
-#ifndef WEBSOCKET_HEADERS_NO_ORIGIN
-	// add origin header if requested
-	handshake += WEBSOCKETS_STRING("Origin: file://\r\n");
-#endif
+	// add extra headers; by default this includes "Origin: file://"
+	handshake += client->extraHeaders + NEW_LINE;
 	
 	handshake += WEBSOCKETS_STRING("User-Agent: arduino-WebSocket-Client\r\n");
 

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -82,7 +82,6 @@ class WebSocketsClient: private WebSockets {
         void setAuthorization(const char * auth);
 	
         void setExtraHeaders(const char * extraHeaders = NULL);
-        void setExtraHeaders(char * extraHeaders);
 
     protected:
         String _host;

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -80,6 +80,9 @@ class WebSocketsClient: private WebSockets {
 
         void setAuthorization(const char * user, const char * password);
         void setAuthorization(const char * auth);
+	
+        void setExtraHeaders(char * extraHeaders);
+        void setExtraHeaders(const char * extraHeaders);
 
     protected:
         String _host;

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -81,8 +81,8 @@ class WebSocketsClient: private WebSockets {
         void setAuthorization(const char * user, const char * password);
         void setAuthorization(const char * auth);
 	
+        void setExtraHeaders(const char * extraHeaders = NULL);
         void setExtraHeaders(char * extraHeaders);
-        void setExtraHeaders(const char * extraHeaders);
 
     protected:
         String _host;


### PR DESCRIPTION
Hi, I had an issue with connecting to a [Spring based SockJS+STOMP endpoint](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html). Specifically the default settings of Spring do not allow an "Origin" header which is hardcoded in the current version of the arduinoWebSockets library. Also, there was no example how to handle SockJS+STOMP.

This pull request adds the capability of removing the hardcoded "Origin" header and enables the user to set custom headers. Additionally it provides an example for connecting to a Spring based SockJS+STOMP endpoint.

There are probably ways to do this more elegantly (like using String arrays to specify headers) or efficiently (e.g., using preprocessor statements), but I opted for the fasted way to implement this. Let me know what you think.

This pull request is somewhat related to issues #131 and #182 . If I have missed already existing functionality, please kindly ignore and delete this request :smirk: 