### PR TITLE
fix undefined virtual methods

### DIFF
--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -272,10 +272,10 @@ class WebSockets {
         typedef std::function<void(WSclient_t * client, bool ok)> WSreadWaitCb;
 #endif
 
-        virtual void clientDisconnect(WSclient_t * client);
-        virtual bool clientIsConnected(WSclient_t * client);
+        virtual void clientDisconnect(WSclient_t * client) = 0;
+        virtual bool clientIsConnected(WSclient_t * client) = 0;
 
-        virtual void messageReceived(WSclient_t * client, WSopcode_t opcode, uint8_t * payload, size_t length, bool fin);
+        virtual void messageReceived(WSclient_t * client, WSopcode_t opcode, uint8_t * payload, size_t length, bool fin) = 0;
 
         void clientDisconnect(WSclient_t * client, uint16_t code, char * reason = NULL, size_t reasonLen = 0);
         bool sendFrame(WSclient_t * client, WSopcode_t opcode, uint8_t * payload = NULL, size_t length = 0, bool mask = false, bool fin = true, bool headerToPayload = false);


### PR DESCRIPTION
without these definitions I'd got the error, when I tried to use templates in my project:
`.pioenvs\d1_mini\lib9ab\libWebSockets_ID549.a(WebSocketsServer.cpp.o):(.rodata._ZTI16WebSocketsServer[_ZTI16WebSocketsServer]+0x10): undefined reference to `typeinfo for WebSockets'
collect2.exe: error: ld returned 1 exit status` 