### PR TITLE
Allow custom WEBSOCKETS_SERVER_CLIENT_MAX definition

### DIFF
--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -27,7 +27,9 @@
 
 #include "WebSockets.h"
 
+#ifndef WEBSOCKETS_SERVER_CLIENT_MAX
 #define WEBSOCKETS_SERVER_CLIENT_MAX  (5)
+#endif
 
 
 


### PR DESCRIPTION
Depending on your application, the Arduino might be low on free heap.

This PR allows the user to modify the `WEBSOCKETS_SERVER_CLIENT_MAX` macro, such that extra RAM can be saved for applications where the number of clients is known to be lower than 5 (the default maximum).