### PR TITLE
Ethernet2

### DIFF
--- a/examples/WebSocketServer/WebSocketServer_ethernetShield2.ino
+++ b/examples/WebSocketServer/WebSocketServer_ethernetShield2.ino
@@ -1,0 +1,82 @@
+#include <Ethernet2.h>
+#include <EthernetClient.h>
+#include <EthernetServer.h>
+#include <EthernetUdp2.h>
+/////////#include <HexDump.h> //downloaded from https://github.com/Yveaux/Arduino_HexDump
+
+#include <WebSocketsServer.h>
+//#include <Hash.h>
+
+#include <Streaming.h>
+
+byte mac[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xEF};
+IPAddress ip(192, 168, 0, 110);
+
+WebSocketsServer webSocket = WebSocketsServer(8081);
+
+#define USE_SERIAL Serial
+
+void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght) {
+
+    switch(type) {
+        case WStype_DISCONNECTED:
+            //USE_SERIAL.printf("[%u] Disconnected!\n", num);
+            USE_SERIAL << num << " Disconnected!" << endl;
+            break;
+        case WStype_CONNECTED:
+            {
+                //IPAddress ip = webSocket.remoteIP(num);
+                //USE_SERIAL.printf("[%u] Connected from %d.%d.%d.%d url: %s\n", num, ip[0], ip[1], ip[2], ip[3], payload);
+				        USE_SERIAL << num << " Connected url: " << int(payload) << endl; 
+				// send message to client
+				webSocket.sendTXT(num, "Connected");
+            }
+            break;
+        case WStype_TEXT:
+            //USE_SERIAL.printf("[%u] get Text: %s\n", num, payload);
+            USE_SERIAL << num << " get Text: " << int(payload) << endl;
+
+            // send message to client
+             webSocket.sendTXT(num, "message here");
+
+            // send data to all connected clients
+             webSocket.broadcastTXT("message here");
+            break;
+        case WStype_BIN:
+            //USE_SERIAL.printf("[%u] get binary lenght: %u\n", num, lenght);
+            USE_SERIAL << num <<" get binary lenght: " << lenght << endl;
+            ///////////hexdump(payload, lenght);
+            
+            // send message to client
+            webSocket.sendBIN(num, payload, lenght);
+            break;
+    }
+
+}
+
+void setup() {
+    // USE_SERIAL.begin(921600);
+    USE_SERIAL.begin(115200);
+
+    Ethernet.begin(mac, ip);
+
+//   USE_SERIAL.setDebugOutput(true);
+
+    USE_SERIAL.println();
+    USE_SERIAL.println();
+    USE_SERIAL.println();
+
+    for(uint8_t t = 4; t > 0; t--) {
+        //USE_SERIAL.printf("[SETUP] BOOT WAIT %d...\n", t);
+        USE_SERIAL.flush();
+        delay(1000);
+    }
+
+
+    webSocket.begin();
+    webSocket.onEvent(webSocketEvent);
+}
+
+void loop() {
+    webSocket.loop();
+}

--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -56,7 +56,11 @@ extern "C" {
  * @param reasonLen
  */
 void WebSockets::clientDisconnect(WSclient_t * client, uint16_t code, char * reason, size_t reasonLen) {
-    DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] clientDisconnect code: %u\n", client->num, code);
+    //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] clientDisconnect code: %u\n", client->num, code);
+    WS_PRINT("[WS][");
+    WS_PRINT(client->num);
+    WS_PRINT("][handleWebsocket] clientDisconnect code: ");
+    WS_PRINTLN(code);
     if(client->status == WSC_CONNECTED && code) {
         if(reason) {
             sendFrame(client, WSop_close, (uint8_t *) reason, reasonLen);
@@ -83,20 +87,45 @@ void WebSockets::clientDisconnect(WSclient_t * client, uint16_t code, char * rea
 void WebSockets::sendFrame(WSclient_t * client, WSopcode_t opcode, uint8_t * payload, size_t length, bool mask, bool fin, bool headerToPayload) {
 
     if(client->tcp && !client->tcp->connected()) {
-        DEBUG_WEBSOCKETS("[WS][%d][sendFrame] not Connected!?\n", client->num);
+        //DEBUG_WEBSOCKETS("[WS][%d][sendFrame] not Connected!?\n", client->num);
+        WS_PRINT("[WS][");
+        WS_PRINT(client->num);
+        WS_PRINTLN("][sendFrame] not Connected!?");
         return;
     }
 
     if(client->status != WSC_CONNECTED) {
-        DEBUG_WEBSOCKETS("[WS][%d][sendFrame] not in WSC_CONNECTED state!?\n", client->num);
+        //DEBUG_WEBSOCKETS("[WS][%d][sendFrame] not in WSC_CONNECTED state!?\n", client->num);
+        WS_PRINT("[WS][");
+        WS_PRINT(client->num);
+        WS_PRINTLN("][sendFrame] not in WSC_CONNECTED state!?");
         return;
     }
 
-    DEBUG_WEBSOCKETS("[WS][%d][sendFrame] ------- send massage frame -------\n", client->num);
-    DEBUG_WEBSOCKETS("[WS][%d][sendFrame] fin: %u opCode: %u mask: %u length: %u headerToPayload: %u\n", client->num, fin, opcode, mask, length, headerToPayload);
+    //DEBUG_WEBSOCKETS("[WS][%d][sendFrame] ------- send massage frame -------\n", client->num);
+    WS_PRINT("[WS][");
+    WS_PRINT(client->num);
+    WS_PRINTLN("][sendFrame] ------- send massage frame -------");
+    //DEBUG_WEBSOCKETS("[WS][%d][sendFrame] fin: %u opCode: %u mask: %u length: %u headerToPayload: %u\n", client->num, fin, opcode, mask, length, headerToPayload);
+    WS_PRINT("[WS][");
+    WS_PRINT(client->num);
+    WS_PRINT("][sendFrame] fin: ");
+    WS_PRINT(fin);
+    WS_PRINT(" opCode: ");
+    WS_PRINT(opcode);
+    WS_PRINT(" mask: ");
+    WS_PRINT(mask);
+    WS_PRINT(" length: ");
+    WS_PRINT(length);
+    WS_PRINT(" headerToPayload: ");
+    WS_PRINTLN(headerToPayload);
 
     if(opcode == WSop_text) {
-        DEBUG_WEBSOCKETS("[WS][%d][sendFrame] text: %s\n", client->num, (payload + (headerToPayload ? 14 : 0)));
+        //DEBUG_WEBSOCKETS("[WS][%d][sendFrame] text: %s\n", client->num, (payload + (headerToPayload ? 14 : 0)));
+        WS_PRINT("[WS][");
+        WS_PRINT(client->num);
+        WS_PRINT("][sendFrame] text: ");
+        WS_PRINTLN(reinterpret_cast<char*>(payload + (headerToPayload ? 14 : 0)));//<<<------------------------------------------------
     }
 
     uint8_t maskKey[4] = { 0x00, 0x00, 0x00, 0x00 };
@@ -125,7 +154,10 @@ void WebSockets::sendFrame(WSclient_t * client, WSopcode_t opcode, uint8_t * pay
     // only for ESP since AVR has less HEAP
     // try to send data in one TCP package (only if some free Heap is there)
     if(!headerToPayload && ((length > 0) && (length < 1400)) && (ESP.getFreeHeap() > 6000)) {
-        DEBUG_WEBSOCKETS("[WS][%d][sendFrame] pack to one TCP package...\n", client->num);
+        //DEBUG_WEBSOCKETS("[WS][%d][sendFrame] pack to one TCP package...\n", client->num);
+        WS_PRINT("[WS][");
+        WS_PRINT(client->num);
+        WS_PRINTLN("][sendFrame] pack to one TCP package...");
         uint8_t * dataPtr = (uint8_t *) malloc(length + WEBSOCKETS_MAX_HEADER_SIZE);
         if(dataPtr) {
             memcpy((dataPtr + WEBSOCKETS_MAX_HEADER_SIZE), payload, length);
@@ -227,7 +259,7 @@ void WebSockets::sendFrame(WSclient_t * client, WSopcode_t opcode, uint8_t * pay
         }
     }
 
-    DEBUG_WEBSOCKETS("[WS][%d][sendFrame] sending Frame Done (%uus).\n", client->num, (micros() - start));
+    ////////////DEBUG_WEBSOCKETS("[WS][%d][sendFrame] sending Frame Done (%uus).\n", client->num, (micros() - start));
 
 #ifdef WEBSOCKETS_USE_BIG_MEM
     if(useInternBuffer && payloadPtr) {
@@ -257,7 +289,10 @@ void WebSockets::handleWebsocket(WSclient_t * client) {
 
     uint8_t * payload = NULL;
 
-    DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] ------- read massage frame -------\n", client->num);
+    //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] ------- read massage frame -------\n", client->num);
+    WS_PRINT("[WS][");
+    WS_PRINT(client->num);
+    WS_PRINTLN("][handleWebsocket] ------- read massage frame -------");
 
     if(!readWait(client, buffer, 2)) {
         //timeout
@@ -298,11 +333,34 @@ void WebSockets::handleWebsocket(WSclient_t * client) {
         }
     }
 
-    DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] fin: %u rsv1: %u rsv2: %u rsv3 %u  opCode: %u\n", client->num, fin, rsv1, rsv2, rsv3, opCode);
-    DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] mask: %u payloadLen: %u\n", client->num, mask, payloadLen);
+    //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] fin: %u rsv1: %u rsv2: %u rsv3 %u  opCode: %u\n", client->num, fin, rsv1, rsv2, rsv3, opCode);
+    WS_PRINT("[WS][");
+    WS_PRINT(client->num);
+    WS_PRINT("][handleWebsocket] fin: ");
+    WS_PRINT(fin);
+    WS_PRINT(" rsv1: ");
+    WS_PRINT(rsv1);
+    WS_PRINT(" rsv2: ");
+    WS_PRINT(rsv2);
+    WS_PRINT(" rsv3: ");
+    WS_PRINT(rsv3);
+    WS_PRINT("  opCode: ");
+    WS_PRINTLN(opCode);
+    //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] mask: %u payloadLen: %u\n", client->num, mask, payloadLen);
+    WS_PRINT("[WS][");
+    WS_PRINT(client->num);
+    WS_PRINT("][handleWebsocket] mask: ");
+    WS_PRINT(mask);
+    WS_PRINT(" payloadLen: ");
+    WS_PRINTLN(payloadLen);
 
     if(payloadLen > WEBSOCKETS_MAX_DATA_SIZE) {
-        DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] payload to big! (%u)\n", client->num, payloadLen);
+        //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] payload to big! (%u)\n", client->num, payloadLen);
+        WS_PRINT("[WS][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleWebsocket] payload to big! (");
+        WS_PRINT(payloadLen);
+        WS_PRINTLN(")");
         clientDisconnect(client, 1009);
         return;
     }
@@ -320,13 +378,21 @@ void WebSockets::handleWebsocket(WSclient_t * client) {
         payload = (uint8_t *) malloc(payloadLen + 1);
 
         if(!payload) {
-            DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] to less memory to handle payload %d!\n", client->num, payloadLen);
+            //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] to less memory to handle payload %d!\n", client->num, payloadLen);
+            WS_PRINT("[WS][");
+            WS_PRINT(client->num);
+            WS_PRINT("][handleWebsocket] to less memory to handle payload ");
+            WS_PRINT(payloadLen);
+            WS_PRINTLN("!");
             clientDisconnect(client, 1011);
             return;
         }
 
         if(!readWait(client, payload, payloadLen)) {
-            DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] missing data!\n", client->num);
+            //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] missing data!\n", client->num);
+            WS_PRINT("[WS][");
+            WS_PRINT(client->num);
+            WS_PRINTLN("][handleWebsocket] missing data!");
             free(payload);
             clientDisconnect(client, 1002);
             return;
@@ -344,7 +410,11 @@ void WebSockets::handleWebsocket(WSclient_t * client) {
 
     switch(opCode) {
         case WSop_text:
-            DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] text: %s\n", client->num, payload);
+            //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] text: %s\n", client->num, payload);
+            WS_PRINT("[WS][");
+            WS_PRINT(client->num);
+            WS_PRINT("][handleWebsocket] text: ");
+            WS_PRINTLN(reinterpret_cast<char*>(payload));//<<<------------------------------------------------
             // no break here!
         case WSop_binary:
             messageRecived(client, opCode, payload, payloadLen);
@@ -354,7 +424,12 @@ void WebSockets::handleWebsocket(WSclient_t * client) {
             sendFrame(client, WSop_pong, payload, payloadLen);
             break;
         case WSop_pong:
-            DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] get pong  (%s)\n", client->num, payload);
+            //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] get pong  (%s)\n", client->num, payload);
+            WS_PRINT("[WS][");
+            WS_PRINT(client->num);
+            WS_PRINT("][handleWebsocket] get pong  (");
+            WS_PRINT(reinterpret_cast<char*>(payload));//<<<------------------------------------------------
+            WS_PRINTLN(")");
             break;
         case WSop_close:
             {
@@ -363,11 +438,19 @@ void WebSockets::handleWebsocket(WSclient_t * client) {
                     reasonCode = payload[0] << 8 | payload[1];
                 }
 
-                DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] get ask for close. Code: %d", client->num, reasonCode);
+                //DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] get ask for close. Code: %d", client->num, reasonCode);
+                WS_PRINT("[WS][");
+                WS_PRINT(client->num);
+                WS_PRINT("][handleWebsocket] get ask for close. Code: ");
+                WS_PRINTLN(reasonCode);
                 if(payloadLen > 2) {
-                    DEBUG_WEBSOCKETS(" (%s)\n", (payload+2));
+                    //DEBUG_WEBSOCKETS(" (%s)\n", (payload+2));
+                    WS_PRINT(" (");
+                    WS_PRINT(reinterpret_cast<char*>(payload+2));//<<<------------------------------------------------
+                    WS_PRINTLN(")");
                 } else {
-                    DEBUG_WEBSOCKETS("\n");
+                    //DEBUG_WEBSOCKETS("\n");
+                    WS_PRINTLN();
                 }
                 clientDisconnect(client, 1000);
             }
@@ -445,17 +528,20 @@ bool WebSockets::readWait(WSclient_t * client, uint8_t *out, size_t n) {
 
     while(n > 0) {
         if(!client->tcp) {
-            DEBUG_WEBSOCKETS("[readWait] tcp is null!\n");
+            //DEBUG_WEBSOCKETS("[readWait] tcp is null!\n");
+            WS_PRINTLN("[readWait] tcp is null!");
             return false;
         }
 
         if(!client->tcp->connected()) {
-            DEBUG_WEBSOCKETS("[readWait] not connected!\n");
+            //DEBUG_WEBSOCKETS("[readWait] not connected!\n");
+            WS_PRINTLN("[readWait] not connected!");
             return false;
         }
 
         if((millis() - t) > WEBSOCKETS_TCP_TIMEOUT) {
-            DEBUG_WEBSOCKETS("[readWait] receive TIMEOUT!\n");
+            //DEBUG_WEBSOCKETS("[readWait] receive TIMEOUT!\n");
+            WS_PRINTLN("[readWait] receive TIMEOUT!");
             return false;
         }
 

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -27,7 +27,7 @@
 
 #include <Arduino.h>
 
-#define DEBUG_WEBSOCKETS
+//#define DEBUG_WEBSOCKETS
 
 #ifdef DEBUG_WEBSOCKETS
 #define WS_PRINT(x) Serial.print(x);
@@ -134,6 +134,7 @@ typedef struct {
         WSclientsStatus_t status;
 
         WEBSOCKETS_NETWORK_CLASS * tcp;
+        WEBSOCKETS_NETWORK_CLASS _client;
 /*
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
         bool isSSL;             ///< run in ssl mode

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -27,12 +27,20 @@
 
 #include <Arduino.h>
 
-//#define DEBUG_WEBSOCKETS(...) Serial1.printf( __VA_ARGS__ )
+#define DEBUG_WEBSOCKETS
 
-#ifndef DEBUG_WEBSOCKETS
-#define DEBUG_WEBSOCKETS(...)
+#ifdef DEBUG_WEBSOCKETS
+#define WS_PRINT(x) Serial.print(x);
+#define WS_PRINTLN(x) Serial.println(x);
+#else 
+#define WS_PRINT(x)
+#define WS_PRINTLN(x)
 #define NODEBUG_WEBSOCKETS
 #endif
+
+
+        //Unmute to select Ethernet2 sheild library
+#define W5500_H
 
 #ifdef ESP8266
 #define WEBSOCKETS_MAX_DATA_SIZE  (15*1024)
@@ -47,11 +55,14 @@
 #define NETWORK_ESP8266     (1)
 #define NETWORK_W5100       (2)
 #define NETWORK_ENC28J60    (3)
+#define NETWORK_W5500       (4)
 
 
 // select Network type based
 #ifdef ESP8266
 #define WEBSOCKETS_NETWORK_TYPE NETWORK_ESP8266
+#elif defined W5500_H
+#define WEBSOCKETS_NETWORK_TYPE NETWORK_W5500
 #else
 #define WEBSOCKETS_NETWORK_TYPE NETWORK_W5100
 #endif
@@ -80,10 +91,17 @@
 #define WEBSOCKETS_NETWORK_CLASS UIPClient
 #define WEBSOCKETS_NETWORK_SERVER_CLASS UIPServer
 
+#elif (WEBSOCKETS_NETWORK_TYPE == NETWORK_W5500)
+#include <Ethernet2.h>
+#include <EthernetClient.h>
+#include <EthernetServer.h>
+#include <SPI.h>
+#define WEBSOCKETS_NETWORK_CLASS EthernetClient
+#define WEBSOCKETS_NETWORK_SERVER_CLASS EthernetServer
+
 #else
 #error "no network type selected!"
 #endif
-
 
 typedef enum {
     WSC_NOT_CONNECTED,
@@ -116,11 +134,11 @@ typedef struct {
         WSclientsStatus_t status;
 
         WEBSOCKETS_NETWORK_CLASS * tcp;
-
+/*
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
         bool isSSL;             ///< run in ssl mode
         WiFiClientSecure * ssl;
-#endif
+#endif*/
 
         String cUrl;        ///< http url
         uint16_t cCode;     ///< http code

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -93,7 +93,8 @@ void WebSocketsClient::loop(void) {
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
         if(_client.isSSL) {
-            DEBUG_WEBSOCKETS("[WS-Client] connect wss...\n");
+            //DEBUG_WEBSOCKETS("[WS-Client] connect wss...\n");
+            WS_PRINTLN("[WS-Client] connect wss...");
             if(_client.ssl) {
                 delete _client.ssl;
                 _client.ssl = NULL;
@@ -102,7 +103,8 @@ void WebSocketsClient::loop(void) {
             _client.ssl = new WiFiClientSecure();
             _client.tcp = _client.ssl;
         } else {
-            DEBUG_WEBSOCKETS("[WS-Client] connect ws...\n");
+            //DEBUG_WEBSOCKETS("[WS-Client] connect ws...\n");
+            WS_PRINTLN("[WS-Client] connect ws...");
             if(_client.tcp) {
                 delete _client.tcp;
                 _client.tcp = NULL;
@@ -114,12 +116,18 @@ void WebSocketsClient::loop(void) {
 #endif
 
         if(!_client.tcp) {
-            DEBUG_WEBSOCKETS("[WS-Client] creating Network class failed!");
+            //DEBUG_WEBSOCKETS("[WS-Client] creating Network class failed!");
+            WS_PRINTLN("[WS-Client] creating Network class failed!");
             return;
         }
 
         if(_client.tcp->connect(_host.c_str(), _port)) {
-            DEBUG_WEBSOCKETS("[WS-Client] connected to %s:%u.\n", _host.c_str(), _port);
+            //DEBUG_WEBSOCKETS("[WS-Client] connected to %s:%u.\n", _host.c_str(), _port);
+            WS_PRINT("[WS-Client] connected to ");
+            WS_PRINT(_host.c_str());
+            WS_PRINT(":");
+            WS_PRINT(_port);
+            WS_PRINTLN(".");
 
             _client.status = WSC_HEADER;
 
@@ -131,7 +139,8 @@ void WebSocketsClient::loop(void) {
 
             if(_client.isSSL && _fingerprint.length()) {
                 if(!_client.ssl->verify(_fingerprint.c_str(), _host.c_str())) {
-                    DEBUG_WEBSOCKETS("[WS-Client] certificate mismatch\n");
+                    //DEBUG_WEBSOCKETS("[WS-Client] creating Network class failed!\n");
+                    WS_PRINTLN("[WS-Client] creating Network class failed!");
                     WebSockets::clientDisconnect(&_client, 1000);
                     return;
                 }
@@ -142,7 +151,12 @@ void WebSocketsClient::loop(void) {
             sendHeader(&_client);
 
         } else {
-            DEBUG_WEBSOCKETS("[WS-Client] connection to %s:%u Faild\n", _host.c_str(), _port);
+            //DEBUG_WEBSOCKETS("[WS-Client] connection to %s:%u Faild\n", _host.c_str(), _port);
+            WS_PRINT("[WS-Client] connection to ");
+            WS_PRINT(_host.c_str());
+            WS_PRINT(":");
+            WS_PRINT(_port);
+            WS_PRINTLN(" Faild");
             delay(10); //some litle delay to not flood the server
         }
     } else {
@@ -281,7 +295,8 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client) {
 
     client->status = WSC_NOT_CONNECTED;
 
-    DEBUG_WEBSOCKETS("[WS-Client] client disconnected.\n");
+    //DEBUG_WEBSOCKETS("[WS-Client] client disconnected.\n");
+    WS_PRINTLN("[WS-Client] client disconnected.");
 
     runCbEvent(WStype_DISCONNECTED, NULL, 0);
 
@@ -305,7 +320,8 @@ bool WebSocketsClient::clientIsConnected(WSclient_t * client) {
     } else {
         // client lost
         if(client->status != WSC_NOT_CONNECTED) {
-            DEBUG_WEBSOCKETS("[WS-Client] connection lost.\n");
+            //DEBUG_WEBSOCKETS("[WS-Client] connection lost.\n");
+            WS_PRINTLN("[WS-Client] connection lost.");
             // do cleanup
             clientDisconnect(client);
         }
@@ -348,7 +364,8 @@ void WebSocketsClient::handleClientData(void) {
  */
 void WebSocketsClient::sendHeader(WSclient_t * client) {
 
-    DEBUG_WEBSOCKETS("[WS-Client][sendHeader] sending header...\n");
+    //DEBUG_WEBSOCKETS("[WS-Client][sendHeader] sending header...\n");
+    WS_PRINTLN("[WS-Client][sendHeader] sending header...");
 
     uint8_t randomKey[16] = { 0 };
 
@@ -379,7 +396,10 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
 
     client->tcp->write(handshake.c_str(), handshake.length());
 
-    DEBUG_WEBSOCKETS("[WS-Client][sendHeader] sending header... Done (%uus).\n", (micros() - start));
+    //DEBUG_WEBSOCKETS("[WS-Client][sendHeader] sending header... Done (%uus).\n", (micros() - start));
+    WS_PRINT("[WS-Client][sendHeader] sending header... Done (");
+    WS_PRINT((micros() - start));
+    WS_PRINTLN("us).");
 
 }
 
@@ -393,7 +413,9 @@ void WebSocketsClient::handleHeader(WSclient_t * client) {
     headerLine.trim(); // remove \r
 
     if(headerLine.length() > 0) {
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader] RX: %s\n", headerLine.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] RX: %s\n", headerLine.c_str());
+        WS_PRINT("[WS-Client][handleHeader] RX: ");
+        WS_PRINTLN(headerLine.c_str());
 
         if(headerLine.startsWith("HTTP/1.")) {
             // "HTTP/1.1 101 Switching Protocols"
@@ -421,24 +443,48 @@ void WebSocketsClient::handleHeader(WSclient_t * client) {
                 client->cVersion = headerValue.toInt();
             }
         } else {
-            DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Header error (%s)\n", headerLine.c_str());
+            //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Header error (%s)\n", headerLine.c_str());
+            WS_PRINT("[WS-Client][handleHeader] Header error (");
+            WS_PRINT(headerLine.c_str());
+            WS_PRINTLN(")");
         }
 
     } else {
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Header read fin.\n");
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Client settings:\n");
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Header read fin.\n");
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Client settings:\n");
+        WS_PRINTLN("[WS-Client][handleHeader] Header read fin.");
+        WS_PRINTLN("[WS-Client][handleHeader] Client settings:");
 
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cURL: %s\n", client->cUrl.c_str());
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cKey: %s\n", client->cKey.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cURL: %s\n", client->cUrl.c_str());
+        WS_PRINT("[WS-Client][handleHeader]  - cURL: ");
+        WS_PRINTLN(client->cUrl.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cKey: %s\n", client->cKey.c_str());
+        WS_PRINTLN("[WS-Client][handleHeader]  - cKey: ");
+        WS_PRINTLN(client->cKey.c_str());
 
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Server header:\n");
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cCode: %d\n", client->cCode);
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cIsUpgrade: %d\n", client->cIsUpgrade);
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cIsWebsocket: %d\n", client->cIsWebsocket);
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cAccept: %s\n", client->cAccept.c_str());
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cProtocol: %s\n", client->cProtocol.c_str());
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cExtensions: %s\n", client->cExtensions.c_str());
-        DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cVersion: %d\n", client->cVersion);
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Server header:\n");
+        WS_PRINTLN("[WS-Client][handleHeader] Server header:");
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cCode: %d\n", client->cCode);
+        WS_PRINT("[WS-Client][handleHeader]  - cCode: ");
+        WS_PRINTLN(client->cCode);
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cIsUpgrade: %d\n", client->cIsUpgrade);
+        WS_PRINT("[WS-Client][handleHeader]  - cIsUpgrade: ");
+        WS_PRINTLN(client->cIsUpgrade);
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cIsWebsocket: %d\n", client->cIsWebsocket);
+        WS_PRINT("[WS-Client][handleHeader]  - cIsWebsocket: ");
+        WS_PRINTLN(client->cIsWebsocket);
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cAccept: %s\n", client->cAccept.c_str());
+        WS_PRINT("[WS-Client][handleHeader]  - cAccept: ");
+        WS_PRINTLN(client->cAccept.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cProtocol: %s\n", client->cProtocol.c_str());
+        WS_PRINT("[WS-Client][handleHeader]  - cProtocol: ");
+        WS_PRINTLN(client->cProtocol.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cExtensions: %s\n", client->cExtensions.c_str());
+        WS_PRINT("[WS-Client][handleHeader]  - cExtensions: ");
+        WS_PRINTLN(client->cExtensions.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Client][handleHeader]  - cVersion: %d\n", client->cVersion);
+        WS_PRINT("[WS-Client][handleHeader]  - cVersion: ");
+        WS_PRINTLN(client->cVersion);
 
         bool ok = (client->cIsUpgrade && client->cIsWebsocket);
 
@@ -451,7 +497,10 @@ void WebSocketsClient::handleHeader(WSclient_t * client) {
                     // todo handle login
                 default:   ///< Server dont unterstand requrst
                     ok = false;
-                    DEBUG_WEBSOCKETS("[WS-Client][handleHeader] serverCode is not 101 (%d)\n", client->cCode);
+                    //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] serverCode is not 101 (%d)\n", client->cCode);
+                    WS_PRINT("[WS-Client][handleHeader] serverCode is not 101 (");
+                    WS_PRINT(client->cCode);
+                    WS_PRINTLN(")");
                     clientDisconnect(client);
                     break;
             }
@@ -464,7 +513,8 @@ void WebSocketsClient::handleHeader(WSclient_t * client) {
                 // generate Sec-WebSocket-Accept key for check
                 String sKey = acceptKey(client->cKey);
                 if(sKey != client->cAccept) {
-                    DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Sec-WebSocket-Accept is wrong\n");
+                    //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Sec-WebSocket-Accept is wrong\n");
+                    WS_PRINTLN("[WS-Client][handleHeader] Sec-WebSocket-Accept is wrong");
                     ok = false;
                 }
             }
@@ -472,14 +522,16 @@ void WebSocketsClient::handleHeader(WSclient_t * client) {
 
         if(ok) {
 
-            DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Websocket connection init done.\n");
+            //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Websocket connection init done.\n");
+            WS_PRINTLN("[WS-Client][handleHeader] Websocket connection init done.");
 
             client->status = WSC_CONNECTED;
 
             runCbEvent(WStype_CONNECTED, (uint8_t *) client->cUrl.c_str(), client->cUrl.length());
 
         } else {
-            DEBUG_WEBSOCKETS("[WS-Client][handleHeader] no Websocket connection close.\n");
+            //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] no Websocket connection close.\n");
+            WS_PRINTLN("[WS-Client][handleHeader] no Websocket connection close.");
             client->tcp->write("This is a webSocket client!");
             clientDisconnect(client);
         }

--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -75,7 +75,8 @@ void WebSocketsServer::begin(void) {
 
     _server->begin();
 
-    DEBUG_WEBSOCKETS("[WS-Server] Server Started.\n");
+    //DEBUG_WEBSOCKETS("[WS-Server] Server Started.\n");
+    WS_PRINTLN("[WS-Server] Server Started.");
 }
 
 /**
@@ -322,7 +323,10 @@ void WebSocketsServer::clientDisconnect(WSclient_t * client) {
 
     client->status = WSC_NOT_CONNECTED;
 
-    DEBUG_WEBSOCKETS("[WS-Server][%d] client disconnected.\n", client->num);
+    //DEBUG_WEBSOCKETS("[WS-Server][%d] client disconnected.\n", client->num);
+    WS_PRINT("[WS-Server][");
+    WS_PRINT(client->num);
+    WS_PRINTLN("] client disconnected.");
 
     runCbEvent(client->num, WStype_DISCONNECTED, NULL, 0);
 
@@ -346,7 +350,10 @@ bool WebSocketsServer::clientIsConnected(WSclient_t * client) {
     } else {
         // client lost
         if(client->status != WSC_NOT_CONNECTED) {
-            DEBUG_WEBSOCKETS("[WS-Server][%d] client connection lost.\n", client->num);
+            //DEBUG_WEBSOCKETS("[WS-Server][%d] client connection lost.\n", client->num);
+            WS_PRINT("[WS-Server][");
+            WS_PRINT(client->num);
+            WS_PRINTLN("] client connection lost.");
             // do cleanup
             clientDisconnect(client);
         }
@@ -382,7 +389,8 @@ void WebSocketsServer::handleNewClients(void) {
                 client->tcp = new WEBSOCKETS_NETWORK_CLASS(_server->available());
 #endif
                 if(!client->tcp) {
-                    DEBUG_WEBSOCKETS("[WS-Client] creating Network class failed!");
+                    //DEBUG_WEBSOCKETS("[WS-Client] creating Network class failed!");
+                    WS_PRINTLN("[WS-Client] creating Network class failed!");
                     return;
                 }
 
@@ -395,9 +403,22 @@ void WebSocketsServer::handleNewClients(void) {
                 client->status = WSC_HEADER;
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
                 IPAddress ip = client->tcp->remoteIP();
-                DEBUG_WEBSOCKETS("[WS-Server][%d] new client from %d.%d.%d.%d\n", client->num, ip[0], ip[1], ip[2], ip[3]);
+                //DEBUG_WEBSOCKETS("[WS-Server][%d] new client from %d.%d.%d.%d\n", client->num, ip[0], ip[1], ip[2], ip[3]);
+                WS_PRINT("[WS-Server][");
+                WS_PRINT(client->num);
+                WS_PRINT("] new client from ");
+                WS_PRINT(ip[0]);
+                WS_PRINT(".");
+                WS_PRINT(ip[1]);
+                WS_PRINT(".");
+                WS_PRINT(ip[2]);
+                WS_PRINT(".");
+                WS_PRINTLN(ip[3]);
 #else
-                DEBUG_WEBSOCKETS("[WS-Server][%d] new client\n", client->num);
+                //DEBUG_WEBSOCKETS("[WS-Server][%d] new client\n", client->num);
+                WS_PRINT("[WS-Server][");
+                WS_PRINT(client->num);
+                WS_PRINTLN("] new client");
 #endif
                 ok = true;
                 break;
@@ -409,9 +430,18 @@ void WebSocketsServer::handleNewClients(void) {
             WEBSOCKETS_NETWORK_CLASS tcpClient = _server->available();
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
             IPAddress ip = client->tcp->remoteIP();
-            DEBUG_WEBSOCKETS("[WS-Server] no free space new client from %d.%d.%d.%d\n", ip[0], ip[1], ip[2], ip[3]);
+            //DEBUG_WEBSOCKETS("[WS-Server] no free space new client from %d.%d.%d.%d\n", ip[0], ip[1], ip[2], ip[3]);
+            WS_PRINT("[WS-Server] no free space new client from ");
+            WS_PRINT(ip[0]);
+            WS_PRINT(".");
+            WS_PRINT(ip[1]);
+            WS_PRINT(".");
+            WS_PRINT(ip[2]);
+            WS_PRINT(".");
+            WS_PRINTLN(ip[3]);
 #else
-            DEBUG_WEBSOCKETS("[WS-Server] no free space new client\n");
+            //DEBUG_WEBSOCKETS("[WS-Server] no free space new client\n");
+            WS_PRINTLN("[WS-Server] no free space new client");
 #endif
             tcpClient.stop();
         }
@@ -465,7 +495,11 @@ void WebSocketsServer::handleHeader(WSclient_t * client) {
     headerLine.trim(); // remove \r
 
     if(headerLine.length() > 0) {
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] RX: %s\n", client->num, headerLine.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] RX: %s\n", client->num, headerLine.c_str());
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader] RX: ");
+        WS_PRINTLN(headerLine.c_str());
 
         // websocket request starts allways with GET see rfc6455
         if(headerLine.startsWith("GET ")) {
@@ -494,19 +528,53 @@ void WebSocketsServer::handleHeader(WSclient_t * client) {
                 client->cExtensions = headerValue;
             }
         } else {
-            DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Header error (%s)\n", headerLine.c_str());
+            //DEBUG_WEBSOCKETS("[WS-Client][handleHeader] Header error (%s)\n", headerLine.c_str());
+            WS_PRINT("[WS-Client][handleHeader] Header error (");
+            WS_PRINT(headerLine.c_str());
+            WS_PRINTLN(")");
         }
 
     } else {
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] Header read fin.\n", client->num);
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] Header read fin.\n", client->num);
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINTLN("][handleHeader] Header read fin.");
 
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cURL: %s\n", client->num, client->cUrl.c_str());
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cIsUpgrade: %d\n", client->num, client->cIsUpgrade);
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cIsWebsocket: %d\n", client->num, client->cIsWebsocket);
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cKey: %s\n", client->num, client->cKey.c_str());
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cProtocol: %s\n", client->num, client->cProtocol.c_str());
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cExtensions: %s\n", client->num, client->cExtensions.c_str());
-        DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cVersion: %d\n", client->num, client->cVersion);
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cURL: %s\n", client->num, client->cUrl.c_str());
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cURL: ");
+        WS_PRINTLN(client->cUrl.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cIsUpgrade: %d\n", client->num, client->cIsUpgrade);
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cIsUpgrade: ");
+        WS_PRINTLN(client->cIsUpgrade);
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cIsWebsocket: %d\n", client->num, client->cIsWebsocket);
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cIsWebsocket: ");
+        WS_PRINTLN(client->cIsWebsocket);
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cKey: %s\n", client->num, client->cKey.c_str());
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cKey: ");
+        WS_PRINTLN(client->cKey.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cProtocol: %s\n", client->num, client->cProtocol.c_str());
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cProtocol: ");
+        WS_PRINTLN(client->cProtocol.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cExtensions: %s\n", client->num, client->cExtensions.c_str());
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cExtensions: ");
+        WS_PRINTLN(client->cExtensions.c_str());
+        //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - cVersion: %d\n", client->num, client->cVersion);
+        WS_PRINT("[WS-Server][");
+        WS_PRINT(client->num);
+        WS_PRINT("][handleHeader]  - cVersion: ");
+        WS_PRINTLN(client->cVersion);
 
         bool ok = (client->cIsUpgrade && client->cIsWebsocket);
 
@@ -524,12 +592,19 @@ void WebSocketsServer::handleHeader(WSclient_t * client) {
 
         if(ok) {
 
-            DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] Websocket connection incomming.\n", client->num);
+            //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] Websocket connection incomming.\n", client->num);
+            WS_PRINT("[WS-Server][");
+            WS_PRINT(client->num);
+            WS_PRINTLN("][handleHeader] Websocket connection incomming.");
 
             // generate Sec-WebSocket-Accept key
             String sKey = acceptKey(client->cKey);
 
-            DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - sKey: %s\n", client->num, sKey.c_str());
+            //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader]  - sKey: %s\n", client->num, sKey.c_str());
+            WS_PRINT("[WS-Server][");
+            WS_PRINT(client->num);
+            WS_PRINT("][handleHeader]  - sKey: ");
+            WS_PRINTLN(sKey.c_str());
 
             client->status = WSC_CONNECTED;
 

--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -85,9 +85,12 @@ protected:
 
         void clientDisconnect(WSclient_t * client);
         bool clientIsConnected(WSclient_t * client);
+        bool clientIsConnected2(WSclient_t & client);
 
-        void handleNewClients(void);
-        void handleClientData(void);
+        //void handleNewClients(void);
+        void handleNewClients(WSclient_t & client);
+        //void handleClientData(void);
+        void handleClientData(WSclient_t & client);
 
         void handleHeader(WSclient_t * client);
 

--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -97,7 +97,10 @@ protected:
          * @param client WSclient_t *  ptr to the client struct
          */
         virtual void handleNonWebsocketConnection(WSclient_t * client) {
-            DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] no Websocket connection close.\n", client->num);
+            //DEBUG_WEBSOCKETS("[WS-Server][%d][handleHeader] no Websocket connection close.\n", client->num);
+            WS_PRINT("[WS-Server][");
+            WS_PRINT(client->num);
+            WS_PRINTLN("][handleHeader] no Websocket connection close.");
             client->tcp->write("HTTP/1.1 400 Bad Request\r\n"
                     "Server: arduino-WebSocket-Server\r\n"
                     "Content-Type: text/plain\r\n"


### PR DESCRIPTION
I recently post on issue for support for ethernet shield2. It have been at the end a little more harder then expected.

First, because there is no #define core variable, you can predict if when it will be define, so you can't do it from the sketch. I add it into websocket.h at the top:
`        //Unmute to select Ethernet2 sheild library
#define W5500_H`

if muted, default is W5100

Second: I remove all printf debugger to replace it with Serial.print macro because arduino does not support printf by default. So, if it add more line of code, it will be more compatible without dependency.

Finally, Hexdump() function in the server example is also not a part of arduino neither websocket lib... I just muted it.

Then it compiled, but did not worked.
Debugger showed that the handler wasn't doing thing in order.
I rearrange and rewrote most of it.

Doing so, I notice that most of the library functions works with pointers. I honestly beleive that I will be better to do it by reference. I started to do some of it.. but the rest will require more time and work...

But for now I share a first working version for review.

Thanks