### PR TITLE
Implementing automatic WS client-side heartbeat

### DIFF
--- a/examples/esp8266/WebSocketClient/WebSocketClient.ino
+++ b/examples/esp8266/WebSocketClient/WebSocketClient.ino
@@ -84,6 +84,12 @@ void setup() {
 
 	// try ever 5000 again if connection has failed
 	webSocket.setReconnectInterval(5000);
+  
+  // start heartbeat (optional)
+  // ping server every 15000 ms
+  // expect pong from server within 3000 ms
+  // consider connection disconnected if pong is not received 2 times
+  webSocket.enableHeartbeat(15000, 3000, 2);
 
 }
 

--- a/library.json
+++ b/library.json
@@ -13,7 +13,7 @@
         "type": "git",
         "url": "https://github.com/Links2004/arduinoWebSockets.git"
     },
-    "version": "2.1.2",
+    "version": "2.1.3",
     "license": "LGPL-2.1",
     "export": {
         "exclude": [

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=WebSockets
-version=2.1.2
+version=2.1.3
 author=Markus Sattler
 maintainer=Markus Sattler
 sentence=WebSockets for Arduino (Server + Client)

--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -689,8 +689,7 @@ void WebSockets::handleHBTimeout(WSclient_t * client){
 
                 if (client->disconnectTimeoutCount && client->pongTimeoutCount >= client->disconnectTimeoutCount){
                     DEBUG_WEBSOCKETS("[HBtimeout] count=%d, DISCONNECTING\n", client->pongTimeoutCount);
-                    client->status = WSC_NOT_CONNECTED;
-                    //clientDisconnect(client);
+                    clientDisconnect(client);
                 }
             } 
         }

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -264,6 +264,13 @@ typedef struct {
         bool cHttpHeadersValid; ///< non-websocket http header validity indicator
         size_t cMandatoryHeadersCount; ///< non-websocket mandatory http headers present count
 
+        bool pongReceived;
+        uint32_t pingInterval;  // how often ping will be sent, 0 means "heartbeat is not active"
+        uint32_t lastPing;      // millis when last pong has been received
+        uint32_t pongTimeout;   // interval in millis after which pong is considered to timeout
+        uint8_t disconnectTimeoutCount;  // after how many subsequent pong timeouts discconnect will happen, 0 means "do not disconnect"
+        uint8_t pongTimeoutCount;   // current pong timeout count     
+
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)
         String cHttpLine;   ///< HTTP header lines
 #endif
@@ -302,6 +309,9 @@ class WebSockets {
         bool readCb(WSclient_t * client, uint8_t *out, size_t n, WSreadWaitCb cb);
         virtual size_t write(WSclient_t * client, uint8_t *out, size_t n);
         size_t write(WSclient_t * client, const char *out);
+
+        void enableHeartbeat(WSclient_t * client, uint32_t pingInterval, uint32_t pongTimeout, uint8_t disconnectTimeoutCount);
+        void handleHBTimeout(WSclient_t * client);
 
 
 };

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -173,11 +173,13 @@ void WebSocketsClient::loop(void) {
 
         }
     } else {
+        handleClientData();
+
         if (_client.status == WSC_CONNECTED){
             handleHBPing();
             handleHBTimeout(&_client);
         }
-        handleClientData();
+        
     }
 }
 #endif
@@ -726,7 +728,7 @@ void WebSocketsClient::connectedCb() {
 }
 
 void WebSocketsClient::connectFailedCb() {
-    DEBUG_WEBSOCKETS("[WS-Client] connection to %s:%u Faild\n", _host.c_str(), _port);
+    DEBUG_WEBSOCKETS("[WS-Client] connection to %s:%u Failed\n", _host.c_str(), _port);
 }
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -86,6 +86,9 @@ class WebSocketsClient: private WebSockets {
 
         void setReconnectInterval(unsigned long time);
 
+        void enableHeartbeat(uint32_t pingInterval, uint32_t pongTimeout, uint8_t disconnectTimeoutCount);
+        void disableHeartbeat();        
+
     protected:
         String _host;
         uint16_t _port;
@@ -114,6 +117,8 @@ class WebSocketsClient: private WebSockets {
 
         void connectedCb();
         void connectFailedCb();
+
+        void handleHBPing(); // send ping in specified intervals
 
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)
         void asyncConnect();


### PR DESCRIPTION
1. automatic WS-client heartbeat (ping/pong based)
1. sending ping in specified intervals
1. expecting pong within specified interval
1. if no pong received specified number of times - consider disconnected

Well, there is one issue with specifying that number of times for disconnect:
Client will try sending pings and if it reaches some threshold (tcp tx buffer?) sendPing can stay "frozen" until tcp times out... But 1-2 is OK.