### PR TITLE
Correct a typo in an ESP8266 example

### DIFF
--- a/examples/esp8266/WebSocketServer/WebSocketServer.ino
+++ b/examples/esp8266/WebSocketServer/WebSocketServer.ino
@@ -16,7 +16,7 @@ ESP8266WiFiMulti WiFiMulti;
 
 WebSocketsServer webSocket = WebSocketsServer(81);
 
-#define USE_SERIAL Serial1
+#define USE_SERIAL Serial
 
 void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t length) {
 


### PR DESCRIPTION
`#define USE_SERIAL Serial1` should be `#define USE_SERIAL Serial`