### PR TITLE
Fix warnings in platformIO

### DIFF
--- a/src/SocketIOclient.cpp
+++ b/src/SocketIOclient.cpp
@@ -161,7 +161,7 @@ void SocketIOclient::handleCbEvent(WStype_t type, uint8_t * payload, size_t leng
                     break;
             }
         } break;
-
+        case WStype_ERROR:
         case WStype_BIN:
         case WStype_FRAGMENT_TEXT_START:
         case WStype_FRAGMENT_BIN_START:

--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -462,7 +462,9 @@ bool WebSocketsServer::newClient(WEBSOCKETS_NETWORK_CLASS * TCPclient) {
 #endif
             client->status = WSC_HEADER;
 #if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32)
+#ifndef NODEBUG_WEBSOCKETS
             IPAddress ip = client->tcp->remoteIP();
+#endif
             DEBUG_WEBSOCKETS("[WS-Server][%d] new client from %d.%d.%d.%d\n", client->num, ip[0], ip[1], ip[2], ip[3]);
 #else
             DEBUG_WEBSOCKETS("[WS-Server][%d] new client\n", client->num);
@@ -635,7 +637,9 @@ void WebSocketsServer::handleNewClients(void) {
         if(!ok) {
             // no free space to handle client
 #if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32)
+#ifndef NODEBUG_WEBSOCKETS
             IPAddress ip = tcpClient->remoteIP();
+#endif
             DEBUG_WEBSOCKETS("[WS-Server] no free space new client from %d.%d.%d.%d\n", ip[0], ip[1], ip[2], ip[3]);
 #else
         DEBUG_WEBSOCKETS("[WS-Server] no free space new client\n");


### PR DESCRIPTION
Fix : warning: enumeration value 'WStype_ERROR' not handled in switch [-Wswitch]
Fix : warning: variable 'ip' set but not used [-Wunused-but-set-variable]