### PR TITLE
Implementing automatic WS server-side heartbeat

### DIFF
--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -91,6 +91,9 @@ class WebSocketsServer : protected WebSockets {
     void setAuthorization(const char * auth);
 
     int connectedClients(bool ping = false);
+    
+    void enableHeartbeat(uint32_t pingInterval, uint32_t pongTimeout, uint8_t disconnectTimeoutCount);
+    void disableHeartbeat();
 
 #if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32)
     IPAddress remoteIP(uint8_t num);
@@ -112,6 +115,10 @@ class WebSocketsServer : protected WebSockets {
     WebSocketServerHttpHeaderValFunc _httpHeaderValidationFunc;
 
     bool _runnning;
+    
+    uint32_t _pingInterval;
+    uint32_t _pongTimeout;
+    uint8_t _disconnectTimeoutCount;
 
     bool newClient(WEBSOCKETS_NETWORK_CLASS * TCPclient);
 
@@ -126,6 +133,8 @@ class WebSocketsServer : protected WebSockets {
 #endif
 
     void handleHeader(WSclient_t * client, String * headerLine);
+    
+    void handleHBPing(WSclient_t * client);    // send ping in specified intervals
 
     /**
          * called if a non Websocket connection is coming in.


### PR DESCRIPTION
Heartbeat Feature was already implemented for WebSocketsClient. The Feature is now transfered to WebSocketsServer, so it can be detected, if the client is responsive.
See pull request #383.