### PR TITLE
avoid flush on esp32, add/fix debugs, longer yield when waiting for data

### DIFF
--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -501,7 +501,7 @@ void WebSockets::handleWebsocketPayloadCb(WSclient_t * client, bool ok, uint8_t 
                     reasonCode = payload[0] << 8 | payload[1];
                 }
 #endif
-                DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] get ask for close. Code: %d", client->num, reasonCode);
+                DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] get ask for close. Code: %d\n", client->num, reasonCode);
                 if(header->payloadLen > 2) {
                     DEBUG_WEBSOCKETS(" (%s)\n", (payload + 2));
                 } else {
@@ -510,6 +510,7 @@ void WebSockets::handleWebsocketPayloadCb(WSclient_t * client, bool ok, uint8_t 
                 clientDisconnect(client, 1000);
             } break;
             default:
+                DEBUG_WEBSOCKETS("[WS][%d][handleWebsocket] got unknown opcode: %d\n", client->num, header->opCode);
                 clientDisconnect(client, 1002);
                 break;
         }
@@ -630,7 +631,7 @@ bool WebSockets::readCb(WSclient_t * client, uint8_t * out, size_t n, WSreadWait
         }
 
         if(!client->tcp->available()) {
-            WEBSOCKETS_YIELD();
+            WEBSOCKETS_YIELD_MORE();
             continue;
         }
 
@@ -643,7 +644,9 @@ bool WebSockets::readCb(WSclient_t * client, uint8_t * out, size_t n, WSreadWait
         } else {
             //DEBUG_WEBSOCKETS("Receive %d left %d!\n", len, n);
         }
-        WEBSOCKETS_YIELD();
+        if (n > 0) {
+            WEBSOCKETS_YIELD();
+        }
     }
     if(cb) {
         cb(client, true);
@@ -693,9 +696,11 @@ size_t WebSockets::write(WSclient_t * client, uint8_t * out, size_t n) {
             total += len;
             //DEBUG_WEBSOCKETS("write %d left %d!\n", len, n);
         } else {
-            //DEBUG_WEBSOCKETS("write %d failed left %d!\n", len, n);
+            DEBUG_WEBSOCKETS("WS write %d failed left %d!\n", len, n);
         }
-        WEBSOCKETS_YIELD();
+        if (n > 0) {
+            WEBSOCKETS_YIELD();
+        }
     }
     WEBSOCKETS_YIELD();
     return total;

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -65,8 +65,10 @@
 
 #if defined(ESP8266)
 #define WEBSOCKETS_YIELD() delay(0)
+#define WEBSOCKETS_YIELD_MORE() delay(1)
 #elif defined(ESP32)
 #define WEBSOCKETS_YIELD() yield()
+#define WEBSOCKETS_YIELD_MORE() delay(1)
 #endif
 
 #elif defined(STM32_DEVICE)

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -77,7 +77,7 @@
 #define WEBSOCKETS_USE_BIG_MEM
 #define GET_FREE_HEAP System.freeMemory()
 #define WEBSOCKETS_YIELD()
-
+#define WEBSOCKETS_YIELD_MORE()
 #else
 
 //atmega328p has only 2KB ram!
@@ -85,7 +85,7 @@
 // moves all Header strings to Flash
 #define WEBSOCKETS_SAVE_RAM
 #define WEBSOCKETS_YIELD()
-
+#define WEBSOCKETS_YIELD_MORE()
 #endif
 
 #define WEBSOCKETS_TCP_TIMEOUT (5000)

--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -567,7 +567,7 @@ void WebSocketsServer::clientDisconnect(WSclient_t * client) {
 
     if(client->tcp) {
         if(client->tcp->connected()) {
-#if(WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
+#if(WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP32)
             client->tcp->flush();
 #endif
             client->tcp->stop();
@@ -694,6 +694,7 @@ void WebSocketsServer::handleClientData(void) {
                         WebSockets::handleWebsocket(client);
                         break;
                     default:
+                        DEBUG_WEBSOCKETS("[WS-Server][%d][handleClientData] unknown client status %d\n", client->num, client->status);
                         WebSockets::clientDisconnect(client, 1002);
                         break;
                 }


### PR DESCRIPTION
flush causes a bunch of reads as we try to close the socket on esp32. I
think flush is broken on that platform. the comments indicate confusion.

added some debug logs for important cases that were missing them, some
missing newlines to existing logs.

added a longer yield when waiting for data, in some super busy cases it
could trigger a task watchdog or otherwise starve the system. (yield
alone doesn't always switch to lower priority tasks)

make some other yields conditional to avoid some waste when it would
double-yield.