### PR TITLE
setFingerprint in WiFiClientSecure required to pass certificate Check

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -170,7 +170,7 @@ void WebSocketsClient::loop(void) {
                 _client.tcp = NULL;
             }
             _client.ssl = new WEBSOCKETS_NETWORK_SSL_CLASS();
-			_client.ssl->setFingerprint(_fingerprint.c_str());
+            _client.ssl->setFingerprint(_fingerprint.c_str());
             _client.tcp = _client.ssl;
             if(_CA_cert) {
                 DEBUG_WEBSOCKETS("[WS-Client] setting CA certificate");

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -170,7 +170,6 @@ void WebSocketsClient::loop(void) {
                 _client.tcp = NULL;
             }
             _client.ssl = new WEBSOCKETS_NETWORK_SSL_CLASS();
-            _client.ssl->setFingerprint(_fingerprint.c_str());
             _client.tcp = _client.ssl;
             if(_CA_cert) {
                 DEBUG_WEBSOCKETS("[WS-Client] setting CA certificate");
@@ -180,6 +179,10 @@ void WebSocketsClient::loop(void) {
                 _client.ssl->setCACert((const uint8_t *)_CA_cert, strlen(_CA_cert) + 1);
 #else
 #error setCACert not implemented
+#endif
+            } else if(_fingerprint.length()) {
+#if defined(wificlientbearssl_h) && !defined(USING_AXTLS) && !defined(wificlientsecure_h)
+                _client.ssl->setFingerprint(_fingerprint.c_str());
 #endif
             }
         } else {

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -170,6 +170,7 @@ void WebSocketsClient::loop(void) {
                 _client.tcp = NULL;
             }
             _client.ssl = new WEBSOCKETS_NETWORK_SSL_CLASS();
+			_client.ssl->setFingerprint(_fingerprint.c_str());
             _client.tcp = _client.ssl;
             if(_CA_cert) {
                 DEBUG_WEBSOCKETS("[WS-Client] setting CA certificate");


### PR DESCRIPTION
Hi,

I'm having trouble with SSL Connection with sockets.streamlabs.com using fingerprint, I found that no fingerprint is passed to WiFiClientSecure so the check break up.
I'm using [SocketIoClient](https://github.com/timum-viw/socket.io-client) and my piece of code is:
```c
webSocket.beginSSL("sockets.streamlabs.com", 443, <query_parameters>, "E7 93 77 36 DA D4 15 0F C1 C1 8F 14 D5 2A C8 72 93 D0 6F 2A");
```
And I receive this log error on connection:
```
[WS-Client] connect wss...
[hostByName] request IP for: sockets.streamlabs.com
[hostByName] Host: sockets.streamlabs.com IP: 3.136.243.104
:ref 1
BSSL:_connectSSL: start connection
BSSL:Connection *will* fail, no authentication method is setup
:wr 227 0
:wrc 227 227 0
:ack 227
:rn 536
:rch 536, 536
:rd 5, 1072, 0
:rdi 536, 5
:rch 1072, 536
:rch 1608, 536
:rd 89, 2144, 5
:rdi 531, 89
:rd 5, 2144, 94
:rdi 442, 5
:rd 2045, 2144, 99
:rdi 437, 437
:c 437, 536, 2144
:rdi 536, 536
:c 536, 536, 1608
:rdi 536, 536
:c 536, 536, 1072
:rdi 536, 536
:c0 536, 536
:rn 536
:rch 536, 536
:rch 1072, 536
:rch 1608, 536
:rd 2144, 2144, 0
:rdi 536, 536
:c 536, 536, 2144
:rdi 536, 536
:c 536, 536, 1608
:rdi 536, 536
:c 536, 536, 1072
:rdi 536, 536
:c0 536, 536
:rn 536
:rch 536, 451
:rd 640, 987, 0
:rdi 536, 536
:c 536, 536, 987
:rdi 451, 104
BSSL:_wait_for_handshake: failed
BSSL:Couldn't connect. Error = 'Certificate is expired or not yet valid.'[WS-Client] connect wss...
[hostByName] request IP for: sockets.streamlabs.com
[hostByName] Host: sockets.streamlabs.com IP: 3.136.243.104
:ref 1
BSSL:_connectSSL: start connection
BSSL:Connection *will* fail, no authentication method is setup
:wr 227 0
:wrc 227 227 0
:ack 227
:rn 536
:rch 536, 536
:rd 5, 1072, 0
:rdi 536, 5
:rch 1072, 536
:rch 1608, 536
:rd 89, 2144, 5
:rdi 531, 89
:rd 5, 2144, 94
:rdi 442, 5
:rd 2045, 2144, 99
:rdi 437, 437
:c 437, 536, 2144
:rdi 536, 536
:c 536, 536, 1608
:rdi 536, 536
:c 536, 536, 1072
:rdi 536, 536
:c0 536, 536
:rn 536
:rch 536, 536
:rch 1072, 536
:rch 1608, 536
:rd 2144, 2144, 0
:rdi 536, 536
:c 536, 536, 2144
:rdi 536, 536
:c 536, 536, 1608
:rdi 536, 536
:c 536, 536, 1072
:rdi 536, 536
:c0 536, 536
:rn 536
:rch 536, 451
:rd 640, 987, 0
:rdi 536, 536
:c 536, 536, 987
:rdi 451, 104
BSSL:_wait_for_handshake: failed
BSSL:Couldn't connect. Error = 'Certificate is expired or not yet valid.'
[WS-Client] connection to sockets.streamlabs.com:443 Failed
:ur 1
:dsrcv 451
:close
:del
[WS-Client] client disconnected.
[SIoC] Disconnected!
[WS-Client] connection to sockets.streamlabs.com:443 Failed
:ur 1
:dsrcv 451
:close
:del
[WS-Client] client disconnected.
[SIoC] Disconnected!
```

As you can see handshake failed and there is this line of log:
 **BSSL:Couldn't connect. Error = 'Certificate is expired or not yet valid.'** 

this is why no fingerprint is valorized.

I made this fix that resolve the problem, let me know if it's ok.