### PR TITLE
Fix for Newline in Headers when extraHeaders is Empty [577]

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -636,7 +636,7 @@ void WebSocketsClient::sendHeader(WSclient_t * client) {
     }
 
     // add extra headers; by default this includes "Origin: file://"
-    if(client->extraHeaders) {
+    if(client->extraHeaders.length() > 0) {
         handshake += client->extraHeaders + NEW_LINE;
     }
 


### PR DESCRIPTION
Closes https://github.com/Links2004/arduinoWebSockets/issues/577