### PR TITLE
WebSocket Server is not closing properly!!

### DIFF
--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -913,7 +913,7 @@ void WebSocketsServer::begin(void) {
 }
 
 void WebSocketsServer::close(void) {
-    WebSocketsServer::close();
+    WebSocketsServerCore::close();
 #if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266)
     _server->close();
 #elif(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)

--- a/src/WebSocketsServer.h
+++ b/src/WebSocketsServer.h
@@ -35,7 +35,9 @@ class WebSocketsServerCore : protected WebSockets {
   public:
     WebSocketsServerCore(const String & origin = "", const String & protocol = "arduino");
     virtual ~WebSocketsServerCore(void);
-
+    
+    WSclient_t * newClient(WEBSOCKETS_NETWORK_CLASS * TCPclient);
+  
     void begin(void);
     void close(void);
 
@@ -116,7 +118,6 @@ class WebSocketsServerCore : protected WebSockets {
     uint32_t _pongTimeout;
     uint8_t _disconnectTimeoutCount;
 
-    WSclient_t * newClient(WEBSOCKETS_NETWORK_CLASS * TCPclient);
 
     void messageReceived(WSclient_t * client, WSopcode_t opcode, uint8_t * payload, size_t length, bool fin);
 


### PR DESCRIPTION
I had to change a few things in order to make this lib work on esp8266 on Async mode using platformio.

But the main reason on this pull request is the mistake on line 916 on WebSocketsServer, the function is calling itself in a eternal loop that will end up eventually breaking the code.

Fix is simple, instead of WebSocketServer::close(), just reference to the proper one WebSocketServerCore::close().