### PR TITLE
Bugfix for issue #632 (SSL without CA fails to connect on arduino-esp32 v1.0.5)

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -229,8 +229,11 @@ void WebSocketsClient::loop(void) {
 #else
 #error setCACert not implemented
 #endif
-#if defined(SSL_BARESSL)
-            } else if(_fingerprint) {
+#if defined(ESP32)
+            } else if(!_fingerprint.length()) {
+                _client.ssl->setInsecure();
+#elif defined(SSL_BARESSL) 
+            } else if(_fingerprint.length()) {
                 _client.ssl->setFingerprint(_fingerprint);
             } else {
                 _client.ssl->setInsecure();
@@ -872,7 +875,7 @@ void WebSocketsClient::connectedCb() {
             return;
         }
 #else
-    if(_client.isSSL && _fingerprint) {
+    if(_client.isSSL && _fingerprint.lenght()) {
 #endif
     } else if(_client.isSSL && !_CA_cert) {
 #if defined(SSL_BARESSL)


### PR DESCRIPTION
Bugfix for issue #632 
- fixed: SSL for ESP32 without CA / fingerprint
- fixed: check for fingerprint
