### PR TITLE
add ldf mode to build with platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,5 +21,8 @@
         "type": "git",
         "url": "https://github.com/Links2004/arduinoWebSockets.git"
     },
-    "version": "2.3.6"
+    "version": "2.3.6",
+    "build": {
+        "libLDFMode": "deep"
+    }
 }


### PR DESCRIPTION
Actually the library will compile only with "chain" mode if you include manually "WiFi.h" in your source. This should solve the problem, without altering the default plaformio.ini of library's users.