### PR TITLE
Optional Function Arguments to set pingInterval, pongTimeout, and diconnectTimeoutCount in socketio client

### DIFF
--- a/src/SocketIOclient.cpp
+++ b/src/SocketIOclient.cpp
@@ -15,39 +15,39 @@ SocketIOclient::SocketIOclient() {
 SocketIOclient::~SocketIOclient() {
 }
 
-void SocketIOclient::begin(const char * host, uint16_t port, const char * url, const char * protocol) {
+void SocketIOclient::begin(const char * host, uint16_t port, const char * url, const char * protocol, uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5) {
     WebSocketsClient::beginSocketIO(host, port, url, protocol);
-    WebSocketsClient::enableHeartbeat(60 * 1000, 90 * 1000, 5);
+    WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 
-void SocketIOclient::begin(String host, uint16_t port, String url, String protocol) {
+void SocketIOclient::begin(String host, uint16_t port, String url, String protocol, uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5) {
     WebSocketsClient::beginSocketIO(host, port, url, protocol);
-    WebSocketsClient::enableHeartbeat(60 * 1000, 90 * 1000, 5);
+    WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 #if defined(HAS_SSL)
-void SocketIOclient::beginSSL(const char * host, uint16_t port, const char * url, const char * protocol) {
+void SocketIOclient::beginSSL(const char * host, uint16_t port, const char * url, const char * protocol,  uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5) {
     WebSocketsClient::beginSocketIOSSL(host, port, url, protocol);
-    WebSocketsClient::enableHeartbeat(60 * 1000, 90 * 1000, 5);
+    WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 
-void SocketIOclient::beginSSL(String host, uint16_t port, String url, String protocol) {
+void SocketIOclient::beginSSL(String host, uint16_t port, String url, String protocol.  uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5) {
     WebSocketsClient::beginSocketIOSSL(host, port, url, protocol);
-    WebSocketsClient::enableHeartbeat(60 * 1000, 90 * 1000, 5);
+    WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 #if defined(SSL_BARESSL)
-void SocketIOclient::beginSSLWithCA(const char * host, uint16_t port, const char * url, const char * CA_cert, const char * protocol) {
+void SocketIOclient::beginSSLWithCA(const char * host, uint16_t port, const char * url, const char * CA_cert, const char * protocol,  uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5) {
     WebSocketsClient::beginSocketIOSSLWithCA(host, port, url, CA_cert, protocol);
-    WebSocketsClient::enableHeartbeat(60 * 1000, 90 * 1000, 5);
+    WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 
-void SocketIOclient::beginSSLWithCA(const char * host, uint16_t port, const char * url, BearSSL::X509List * CA_cert, const char * protocol) {
+void SocketIOclient::beginSSLWithCA(const char * host, uint16_t port, const char * url, BearSSL::X509List * CA_cert, const char * protocol,  uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5) {
     WebSocketsClient::beginSocketIOSSLWithCA(host, port, url, CA_cert, protocol);
-    WebSocketsClient::enableHeartbeat(60 * 1000, 90 * 1000, 5);
+    WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 

--- a/src/SocketIOclient.h
+++ b/src/SocketIOclient.h
@@ -47,15 +47,15 @@ class SocketIOclient : protected WebSocketsClient {
     SocketIOclient(void);
     virtual ~SocketIOclient(void);
 
-    void begin(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * protocol = "arduino");
-    void begin(String host, uint16_t port, String url = "/socket.io/?EIO=3", String protocol = "arduino");
+    void begin(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
+    void begin(String host, uint16_t port, String url = "/socket.io/?EIO=3", String protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
 
 #ifdef HAS_SSL
-    void beginSSL(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * protocol = "arduino");
-    void beginSSL(String host, uint16_t port, String url = "/socket.io/?EIO=3", String protocol = "arduino");
+    void beginSSL(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
+    void beginSSL(String host, uint16_t port, String url = "/socket.io/?EIO=3", String protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
 #ifndef SSL_AXTLS
-    void beginSSLWithCA(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * CA_cert = NULL, const char * protocol = "arduino");
-    void beginSSLWithCA(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", BearSSL::X509List * CA_cert = NULL, const char * protocol = "arduino");
+    void beginSSLWithCA(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * CA_cert = NULL, const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
+    void beginSSLWithCA(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", BearSSL::X509List * CA_cert = NULL, const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
     void setSSLClientCertKey(const char * clientCert = NULL, const char * clientPrivateKey = NULL);
     void setSSLClientCertKey(BearSSL::X509List * clientCert = NULL, BearSSL::PrivateKey * clientPrivateKey = NULL);
 #endif


### PR DESCRIPTION
changing the pingInterval, pongTimeout of the heartbeat required accessing the library and making changes there.
Instead have added a provision to set them up in the begin function itself, using optional function arguments. This doesn't break any firmwares written on the older functions, as the arguments are optional and carry the default value used in the library.
