### PR TITLE
Suppress `esp32/sha.h` warning

### DIFF
--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -42,9 +42,13 @@ extern "C" {
 #include <esp_system.h>
 
 #if ESP_IDF_VERSION_MAJOR >= 4
-#include <esp32/sha.h>
+  #if ( ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(1, 0, 6) )
+    #include "sha/sha_parallel_engine.h"
+  #else
+    #include <esp32/sha.h>
+  #endif  
 #else
-#include <hwcrypto/sha.h>
+  #include <hwcrypto/sha.h>
 #endif
 
 #else


### PR DESCRIPTION
To fix [**warning sha.h is deprecated, use sha_parallel_engine.h** #738](https://github.com/Links2004/arduinoWebSockets/issues/738)