### PR TITLE
Fix compiler warning "function may return address of local variable"

### DIFF
--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -627,6 +627,7 @@ WSclient_t * WebSocketsServerCore::handleNewClient(WEBSOCKETS_NETWORK_CLASS * tc
         client           = &dummy;
         client->tcp      = tcpClient;
         dropNativeClient(client);
+        return nullptr;
     }
 
     WEBSOCKETS_YIELD();


### PR DESCRIPTION
```
WebSocketsServer.cpp: In member function 'WSclient_t* WebSocketsServerCore::handleNewClient(WiFiClient*)':
WebSocketsServer.cpp:634:12: warning: function may return address of local variable [-Wreturn-local-addr]
     return client;
            ^~~~~~
WebSocketsServer.cpp:626:20: note: declared here
         WSclient_t dummy = WSclient_t();
```

If the check in line 615 is true, the address of a local variable is returned. 
This commit prevents this and thus avoids the compiler warning.