### PR TITLE
Expose WEBSOCKETS_MAX_DATA_SIZE to library users

### DIFF
--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -328,7 +328,7 @@ void WebSockets::headerDone(WSclient_t * client) {
     client->status    = WSC_CONNECTED;
     client->cWsRXsize = 0;
     DEBUG_WEBSOCKETS("[WS][%d][headerDone] Header Handling Done.\n", client->num);
-#if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC)
+#if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC || NETWORK_ESP32_ASYNC)
     client->cHttpLine = "";
     handleWebsocket(client);
 #endif

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -110,6 +110,7 @@
 #define NETWORK_ENC28J60 (3)
 #define NETWORK_ESP32 (4)
 #define NETWORK_ESP32_ETH (5)
+#define NETWORK_ESP32_ASYNC (6)
 
 // max size of the WS Message Header
 #define WEBSOCKETS_MAX_HEADER_SIZE (14)
@@ -200,6 +201,15 @@
 #define WEBSOCKETS_NETWORK_CLASS WiFiClient
 #define WEBSOCKETS_NETWORK_SSL_CLASS WiFiClientSecure
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
+
+#elif (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32_ASYNC)
+
+#include <AsyncTCP.h>
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#define SSL_AXTLS
+#define WEBSOCKETS_NETWORK_CLASS AsyncClient
+#define WEBSOCKETS_NETWORK_SERVER_CLASS AsyncServer
 
 #elif(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32_ETH)
 

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -63,7 +63,9 @@
 
 #if defined(ESP8266) || defined(ESP32)
 
+#ifndef WEBSOCKETS_MAX_DATA_SIZE
 #define WEBSOCKETS_MAX_DATA_SIZE (15 * 1024)
+#endif
 #define WEBSOCKETS_USE_BIG_MEM
 #define GET_FREE_HEAP ESP.getFreeHeap()
 // moves all Header strings to Flash (~300 Byte)
@@ -79,7 +81,9 @@
 
 #elif defined(STM32_DEVICE)
 
+#ifndef WEBSOCKETS_MAX_DATA_SIZE
 #define WEBSOCKETS_MAX_DATA_SIZE (15 * 1024)
+#endif
 #define WEBSOCKETS_USE_BIG_MEM
 #define GET_FREE_HEAP System.freeMemory()
 #define WEBSOCKETS_YIELD()
@@ -87,7 +91,9 @@
 #else
 
 // atmega328p has only 2KB ram!
+#ifndef WEBSOCKETS_MAX_DATA_SIZE
 #define WEBSOCKETS_MAX_DATA_SIZE (1024)
+#endif
 // moves all Header strings to Flash
 #define WEBSOCKETS_SAVE_RAM
 #define WEBSOCKETS_YIELD()


### PR DESCRIPTION
if not defined added for WEBSOCKETS_MAX_DATA_SIZE  to enable an user overwrite to increase max size of transmitted frames.