### PR TITLE
Remove space in search for session (io=) in cookie

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -735,7 +735,7 @@ void WebSocketsClient::handleHeader(WSclient_t * client, String * headerLine) {
                 client->cExtensions = headerValue;
             } else if(headerName.equalsIgnoreCase(WEBSOCKETS_STRING("Sec-WebSocket-Version"))) {
                 client->cVersion = headerValue.toInt();
-            } else if(headerName.equalsIgnoreCase(WEBSOCKETS_STRING("Set-Cookie")) && headerValue.indexOf(" io=") > -1) {
+            } else if(headerName.equalsIgnoreCase(WEBSOCKETS_STRING("Set-Cookie")) && headerValue.indexOf("io=") > -1) {
                 if(headerValue.indexOf(';') > -1) {
                     client->cSessionId = headerValue.substring(headerValue.indexOf('=') + 1, headerValue.indexOf(";"));
                 } else {


### PR DESCRIPTION
As the space was previously removed and will not be found. This fixes finding the session during connection negotiation, and the repeated disconnects.