### PR TITLE
Avoid buffer overflow for small Basic Authentication header

### DIFF
--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -571,6 +571,7 @@ String WebSockets::acceptKey(String & clientKey) {
  */
 String WebSockets::base64_encode(uint8_t * data, size_t length) {
     size_t size   = ((length * 1.6f) + 1);
+    size = std::max(size, (size_t) 5); //minimum buffer size
     char * buffer = (char *)malloc(size);
     if(buffer) {
         base64_encodestate _state;


### PR DESCRIPTION
This PR fixes a crash which occurs for small input lengths of the `base64_encode` function.

For a very small `auth` (length < 3), the `base64_encode` function fails when reaching the following line:

https://github.com/Links2004/arduinoWebSockets/blob/751cf87b6cd684c9d339f0314a18b0ee866d449c/src/WebSockets.cpp#L582C22-L582C22

This is the error message on the console:

```
CORRUPT HEAP: Bad tail at 0x3ffbdb1c. Expected 0xbaad5678 got 0xbaad5600

assert failed: multi_heap_free multi_heap_poisoning.c:253 (head != NULL)
```

Probably it is due to a buffer overflow. With a minimum buffer size of 5, this crash doesn't occur anymore.

To test the fix, I called `WebSocketsClient::setAuthorization(const char * user, const char * password)` with user `""` and password `"b"`.

Btw. and thanks for providing this library. I've been using it for years now and always enjoyed working with it.