### PR TITLE
Allow definition of custom network interfaces

### DIFF
--- a/examples/esp32_pio/CustomNetworkClient/.clang-format
+++ b/examples/esp32_pio/CustomNetworkClient/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/examples/esp32_pio/CustomNetworkClient/.gitignore
+++ b/examples/esp32_pio/CustomNetworkClient/.gitignore
@@ -1,0 +1,2 @@
+.pio
+.vscode

--- a/examples/esp32_pio/CustomNetworkClient/platformio.ini
+++ b/examples/esp32_pio/CustomNetworkClient/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+build_flags = 
+    -DCORE_DEBUG_LEVEL=5
+    -D WEBSOCKETS_NETWORK_TYPE=10
+	-D TINY_GSM_MODEM_SIM7600
+lib_deps =
+    digitaldragon/SSLClient@^1.3.2
+    vshymanskyy/StreamDebugger@^1.0.1
+	vshymanskyy/TinyGSM@^0.12.0
+    symlink://../../..

--- a/examples/esp32_pio/CustomNetworkClient/platformio.ini
+++ b/examples/esp32_pio/CustomNetworkClient/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@6.11.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200

--- a/examples/esp32_pio/CustomNetworkClient/readme.md
+++ b/examples/esp32_pio/CustomNetworkClient/readme.md
@@ -1,0 +1,3 @@
+This example project shows how to use a custom NetworkClient class to switch between two underlying network interfaces.
+
+In this case it shows how a board can support Wi-Fi as well as GSM/LTE connectivity. It uses a shim to switch between the two network interfaces, thereby allowing a single binary to handle both interfaces without needing to reboot. This example can be extended to cover other network interfaces that conform to the Client() class interface.

--- a/examples/esp32_pio/CustomNetworkClient/src/main.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/main.cpp
@@ -1,0 +1,126 @@
+/*
+ * main.cpp
+ *
+ *  Created on: 15.06.2024
+ *
+ */
+
+#include <Arduino.h>
+#include <WebSocketsClient.h>
+#include <WiFiMulti.h>
+
+#include "network_client_impl.h"
+
+WiFiMulti wifiMulti;
+WebSocketsClient webSocket;
+
+#define USE_SERIAL Serial
+
+void setClock() {
+  configTime(0, 0, "pool.ntp.org", "time.nist.gov");
+
+  USE_SERIAL.print(F("Waiting for NTP time sync: "));
+  time_t nowSecs = time(nullptr);
+  while (nowSecs < 8 * 3600 * 2) {
+    delay(500);
+    USE_SERIAL.print(F("."));
+    yield();
+    nowSecs = time(nullptr);
+  }
+
+  USE_SERIAL.println();
+  struct tm timeinfo;
+  gmtime_r(&nowSecs, &timeinfo);
+  USE_SERIAL.print(F("Current time: "));
+  USE_SERIAL.print(asctime(&timeinfo));
+}
+
+void hexdump(const void *mem, uint32_t len, uint8_t cols = 16) {
+  const uint8_t *src = (const uint8_t *)mem;
+  USE_SERIAL.printf("\n[HEXDUMP] Address: 0x%08X len: 0x%X (%d)",
+                    (ptrdiff_t)src, len, len);
+  for (uint32_t i = 0; i < len; i++) {
+    if (i % cols == 0) {
+      USE_SERIAL.printf("\n[0x%08X] 0x%08X: ", (ptrdiff_t)src, i);
+    }
+    USE_SERIAL.printf("%02X ", *src);
+    src++;
+  }
+  USE_SERIAL.printf("\n");
+}
+
+void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
+  switch (type) {
+    case WStype_DISCONNECTED:
+      USE_SERIAL.printf("[WSc] Disconnected!\n");
+      break;
+    case WStype_CONNECTED:
+      USE_SERIAL.printf("[WSc] Connected to url: %s\n", payload);
+
+      // send message to server when Connected
+      webSocket.sendTXT("Connected");
+      break;
+    case WStype_TEXT:
+      USE_SERIAL.printf("[WSc] get text: %s\n", payload);
+
+      // send message to server
+      // webSocket.sendTXT("message here");
+      break;
+    case WStype_BIN:
+      USE_SERIAL.printf("[WSc] get binary length: %u\n", length);
+      hexdump(payload, length);
+
+      // send data to server
+      // webSocket.sendBIN(payload, length);
+      break;
+    case WStype_ERROR:
+    case WStype_FRAGMENT_TEXT_START:
+    case WStype_FRAGMENT_BIN_START:
+    case WStype_FRAGMENT:
+    case WStype_FRAGMENT_FIN:
+      break;
+  }
+}
+
+void setup() {
+  USE_SERIAL.begin(115200);
+
+  USE_SERIAL.setDebugOutput(true);
+
+  USE_SERIAL.println();
+  USE_SERIAL.println();
+  USE_SERIAL.println();
+
+  for (uint8_t t = 4; t > 0; t--) {
+    USE_SERIAL.printf("[SETUP] BOOT WAIT %d...\n", t);
+    USE_SERIAL.flush();
+    delay(1000);
+  }
+
+  wifiMulti.addAP("Berge", "BlauerHimmel!");
+
+  // WiFi.disconnect();
+  while (wifiMulti.run() != WL_CONNECTED) {
+    delay(100);
+  }
+
+  // Call to enable WiFi interface to be used by the webSocketClient
+  NetworkClient::Impl::enableWifi();
+
+  setClock();
+
+  // server address, port and URL. This server can be flakey.
+  // Expected response: Request served by 0123456789abcdef
+  webSocket.beginSSL("echo.websocket.org", 443, "/");
+
+  // event handler
+  webSocket.onEvent(webSocketEvent);
+
+  // use HTTP Basic Authorization this is optional enable if needed
+  // webSocket.setAuthorization("user", "Password");
+
+  // try ever 5000 again if connection has failed
+  webSocket.setReconnectInterval(5000);
+}
+
+void loop() { webSocket.loop(); }

--- a/examples/esp32_pio/CustomNetworkClient/src/main.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/main.cpp
@@ -105,7 +105,7 @@ void setup() {
   }
 
   // Call to enable WiFi interface to be used by the webSocketClient
-  NetworkClient::Impl::enableWifi();
+  WebSocketsNetworkClient::Impl::enableWifi();
 
   setClock();
 

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client.cpp
@@ -1,11 +1,12 @@
 #include "network_client_impl.h"
 
-NetworkClient::NetworkClient() : _impl(new NetworkClient::Impl()) {}
-NetworkClient::NetworkClient(WiFiClient wifi_client)
-    : _impl(new NetworkClient::Impl()) {}
-NetworkClient::~NetworkClient() {}
+WebSocketsNetworkClient::WebSocketsNetworkClient()
+    : _impl(new WebSocketsNetworkClient::Impl()) {}
+WebSocketsNetworkClient::WebSocketsNetworkClient(WiFiClient wifi_client)
+    : _impl(new WebSocketsNetworkClient::Impl()) {}
+WebSocketsNetworkClient::~WebSocketsNetworkClient() {}
 
-int NetworkClient::connect(IPAddress ip, uint16_t port) {
+int WebSocketsNetworkClient::connect(IPAddress ip, uint16_t port) {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->connect(ip, port);
   } else if (_impl->wifi_client_) {
@@ -15,7 +16,7 @@ int NetworkClient::connect(IPAddress ip, uint16_t port) {
   return 0;
 }
 
-int NetworkClient::connect(const char *host, uint16_t port) {
+int WebSocketsNetworkClient::connect(const char *host, uint16_t port) {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->connect(host, port);
   } else if (_impl->wifi_client_) {
@@ -24,8 +25,8 @@ int NetworkClient::connect(const char *host, uint16_t port) {
   Serial.println(_impl->no_interface_error_);
   return 0;
 }
-int NetworkClient::connect(const char *host, uint16_t port,
-                           int32_t timeout_ms) {
+int WebSocketsNetworkClient::connect(const char *host, uint16_t port,
+                                     int32_t timeout_ms) {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->connect(host, port, timeout_ms);
   } else if (_impl->wifi_client_) {
@@ -35,7 +36,7 @@ int NetworkClient::connect(const char *host, uint16_t port,
   return 0;
 }
 
-size_t NetworkClient::write(uint8_t data) {
+size_t WebSocketsNetworkClient::write(uint8_t data) {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->write(data);
   } else if (_impl->wifi_client_) {
@@ -45,7 +46,7 @@ size_t NetworkClient::write(uint8_t data) {
   return 0;
 }
 
-size_t NetworkClient::write(const uint8_t *buf, size_t size) {
+size_t WebSocketsNetworkClient::write(const uint8_t *buf, size_t size) {
   Serial.printf("Send_: %zu\n", size);
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->write(buf, size);
@@ -56,7 +57,7 @@ size_t NetworkClient::write(const uint8_t *buf, size_t size) {
   return 0;
 }
 
-size_t NetworkClient::write(const char *str) {
+size_t WebSocketsNetworkClient::write(const char *str) {
   const int size = strlen(str);
   Serial.printf("Send: %zu\n", size);
   if (_impl->gsm_client_) {
@@ -68,7 +69,7 @@ size_t NetworkClient::write(const char *str) {
   return 0;
 }
 
-int NetworkClient::available() {
+int WebSocketsNetworkClient::available() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->available();
   } else if (_impl->wifi_client_) {
@@ -78,7 +79,7 @@ int NetworkClient::available() {
   return 0;
 }
 
-int NetworkClient::read() {
+int WebSocketsNetworkClient::read() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->read();
   } else if (_impl->wifi_client_) {
@@ -88,7 +89,7 @@ int NetworkClient::read() {
   return 0;
 }
 
-int NetworkClient::read(uint8_t *buf, size_t size) {
+int WebSocketsNetworkClient::read(uint8_t *buf, size_t size) {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->read(buf, size);
   } else if (_impl->wifi_client_) {
@@ -98,7 +99,7 @@ int NetworkClient::read(uint8_t *buf, size_t size) {
   return 0;
 }
 
-int NetworkClient::peek() {
+int WebSocketsNetworkClient::peek() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->peek();
   } else if (_impl->wifi_client_) {
@@ -108,7 +109,7 @@ int NetworkClient::peek() {
   return 0;
 }
 
-void NetworkClient::flush() {
+void WebSocketsNetworkClient::flush() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->flush();
   } else if (_impl->wifi_client_) {
@@ -117,7 +118,7 @@ void NetworkClient::flush() {
   Serial.println(_impl->no_interface_error_);
 }
 
-void NetworkClient::stop() {
+void WebSocketsNetworkClient::stop() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->stop();
   } else if (_impl->wifi_client_) {
@@ -126,7 +127,7 @@ void NetworkClient::stop() {
   Serial.println(_impl->no_interface_error_);
 }
 
-uint8_t NetworkClient::connected() {
+uint8_t WebSocketsNetworkClient::connected() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->connected();
   } else if (_impl->wifi_client_) {
@@ -136,7 +137,7 @@ uint8_t NetworkClient::connected() {
   return 0;
 }
 
-NetworkClient::operator bool() {
+WebSocketsNetworkClient::operator bool() {
   if (_impl->gsm_client_) {
     return _impl->gsm_client_->operator bool();
   } else if (_impl->wifi_client_) {

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client.cpp
@@ -1,0 +1,147 @@
+#include "network_client_impl.h"
+
+NetworkClient::NetworkClient() : _impl(new NetworkClient::Impl()) {}
+NetworkClient::NetworkClient(WiFiClient wifi_client)
+    : _impl(new NetworkClient::Impl()) {}
+NetworkClient::~NetworkClient() {}
+
+int NetworkClient::connect(IPAddress ip, uint16_t port) {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->connect(ip, port);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->connect(ip, port);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClient::connect(const char *host, uint16_t port) {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->connect(host, port);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->connect(host, port);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+int NetworkClient::connect(const char *host, uint16_t port,
+                           int32_t timeout_ms) {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->connect(host, port, timeout_ms);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->connect(host, port, timeout_ms);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+size_t NetworkClient::write(uint8_t data) {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->write(data);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->write(data);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+size_t NetworkClient::write(const uint8_t *buf, size_t size) {
+  Serial.printf("Send_: %zu\n", size);
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->write(buf, size);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->write(buf, size);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+size_t NetworkClient::write(const char *str) {
+  const int size = strlen(str);
+  Serial.printf("Send: %zu\n", size);
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->write((const uint8_t *)str, size);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->write((const uint8_t *)str, size);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClient::available() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->available();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->available();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClient::read() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->read();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->read();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClient::read(uint8_t *buf, size_t size) {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->read(buf, size);
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->read(buf, size);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClient::peek() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->peek();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->peek();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+void NetworkClient::flush() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->flush();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->flush();
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+void NetworkClient::stop() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->stop();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->stop();
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+uint8_t NetworkClient::connected() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->connected();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->connected();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+NetworkClient::operator bool() {
+  if (_impl->gsm_client_) {
+    return _impl->gsm_client_->operator bool();
+  } else if (_impl->wifi_client_) {
+    return _impl->wifi_client_->operator bool();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.cpp
@@ -1,8 +1,8 @@
 #include "network_client_impl.h"
 
-std::unique_ptr<WiFiClient> NetworkClient::Impl::wifi_client_ = nullptr;
-std::unique_ptr<WiFiClientSecure> NetworkClient::Impl::wifi_client_secure_ =
+std::unique_ptr<WiFiClient> WebSocketsNetworkClient::Impl::wifi_client_ = nullptr;
+std::unique_ptr<WiFiClientSecure> WebSocketsNetworkClient::Impl::wifi_client_secure_ =
     nullptr;
-std::unique_ptr<TinyGsmClient> NetworkClient::Impl::gsm_client_ = nullptr;
-std::unique_ptr<SSLClient> NetworkClient::Impl::gsm_client_secure_ = nullptr;
-const char *NetworkClient::Impl::no_interface_error_ = "No interface";
+std::unique_ptr<TinyGsmClient> WebSocketsNetworkClient::Impl::gsm_client_ = nullptr;
+std::unique_ptr<SSLClient> WebSocketsNetworkClient::Impl::gsm_client_secure_ = nullptr;
+const char *WebSocketsNetworkClient::Impl::no_interface_error_ = "No interface";

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.cpp
@@ -1,0 +1,8 @@
+#include "network_client_impl.h"
+
+std::unique_ptr<WiFiClient> NetworkClient::Impl::wifi_client_ = nullptr;
+std::unique_ptr<WiFiClientSecure> NetworkClient::Impl::wifi_client_secure_ =
+    nullptr;
+std::unique_ptr<TinyGsmClient> NetworkClient::Impl::gsm_client_ = nullptr;
+std::unique_ptr<SSLClient> NetworkClient::Impl::gsm_client_secure_ = nullptr;
+const char *NetworkClient::Impl::no_interface_error_ = "No interface";

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.h
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <NetworkClientSecure.h>
 #include <SSLClient.h>
 #include <TinyGSM.h>
+#include <WebSocketsNetworkClientSecure.h>
 #include <WiFiClientSecure.h>
 
-struct NetworkClient::Impl {
+struct WebSocketsNetworkClient::Impl {
   static void enableWifi() {
     // Do nothing if already enabled
     if (wifi_client_ && wifi_client_secure_) {

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.h
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client_impl.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <NetworkClientSecure.h>
+#include <SSLClient.h>
+#include <TinyGSM.h>
+#include <WiFiClientSecure.h>
+
+struct NetworkClient::Impl {
+  static void enableWifi() {
+    // Do nothing if already enabled
+    if (wifi_client_ && wifi_client_secure_) {
+      return;
+    }
+    wifi_client_ = std::unique_ptr<WiFiClient>(new WiFiClient());
+    wifi_client_secure_ =
+        std::unique_ptr<WiFiClientSecure>(new WiFiClientSecure());
+  }
+  static void disableWifi() {
+    wifi_client_ = nullptr;
+    wifi_client_secure_ = nullptr;
+  }
+  static void enableGsm(TinyGsm* tiny_gsm) {
+    // Do nothing if already enabled
+    if (gsm_client_ && gsm_client_secure_) {
+      return;
+    }
+    gsm_client_ = std::unique_ptr<TinyGsmClient>(new TinyGsmClient(*tiny_gsm));
+    gsm_client_secure_ =
+        std::unique_ptr<SSLClient>(new SSLClient(gsm_client_.get()));
+  }
+  static void disableGsm() {
+    if (gsm_client_secure_) {
+      gsm_client_secure_->stop();
+    }
+    gsm_client_secure_ = nullptr;
+    gsm_client_ = nullptr;
+  }
+
+  static std::unique_ptr<WiFiClient> wifi_client_;
+  static std::unique_ptr<WiFiClientSecure> wifi_client_secure_;
+  static std::unique_ptr<TinyGsmClient> gsm_client_;
+  static std::unique_ptr<SSLClient> gsm_client_secure_;
+
+  static const char* no_interface_error_;
+};

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client_secure.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client_secure.cpp
@@ -1,0 +1,190 @@
+#include "network_client_impl.h"
+
+NetworkClientSecure::NetworkClientSecure() {}
+NetworkClientSecure::NetworkClientSecure(WiFiClient wifi_client) {}
+NetworkClientSecure::~NetworkClientSecure() {
+  if (_impl->gsm_client_secure_) {
+    _impl->gsm_client_secure_->stop();
+  }
+}
+
+int NetworkClientSecure::connect(IPAddress ip, uint16_t port) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->connect(ip, port);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->connect(ip, port);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClientSecure::connect(const char *host, uint16_t port) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->connect(host, port);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->connect(host, port);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+int NetworkClientSecure::connect(const char *host, uint16_t port,
+                                 int32_t timeout_ms) {
+  if (_impl->gsm_client_secure_) {
+    // Ignore timeout as will cause read() to block for specified time
+    return _impl->gsm_client_secure_->connect(host, port);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->connect(host, port, timeout_ms);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+size_t NetworkClientSecure::write(uint8_t data) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->write(data);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->write(data);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+size_t NetworkClientSecure::write(const uint8_t *buf, size_t size) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->write(buf, size);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->write(buf, size);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+size_t NetworkClientSecure::write(const char *str) {
+  const int size = strlen(str);
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->write((const uint8_t *)str, size);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->write((const uint8_t *)str, size);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClientSecure::available() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->available();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->available();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClientSecure::read() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->read();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->read();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClientSecure::read(uint8_t *buf, size_t size) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->read(buf, size);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->read(buf, size);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+int NetworkClientSecure::peek() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->peek();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->peek();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+void NetworkClientSecure::flush() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->flush();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->flush();
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+void NetworkClientSecure::stop() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->stop();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->stop();
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+uint8_t NetworkClientSecure::connected() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->connected();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->connected();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+NetworkClientSecure::operator bool() {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->operator bool();
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->operator bool();
+  }
+  Serial.println(_impl->no_interface_error_);
+  return 0;
+}
+
+void NetworkClientSecure::setCACert(const char *rootCA) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->setCertificate(rootCA);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->setCACert(rootCA);
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+void NetworkClientSecure::setCACertBundle(const uint8_t *bundle) {
+  if (_impl->gsm_client_secure_) {
+    return _impl->gsm_client_secure_->setCACertBundle(bundle);
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->setCACertBundle(bundle);
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+void NetworkClientSecure::setInsecure() {
+  if (_impl->gsm_client_secure_) {
+    _impl->gsm_client_secure_->setInsecure();
+  } else if (_impl->wifi_client_secure_) {
+    _impl->wifi_client_secure_->setInsecure();
+  }
+  Serial.println(_impl->no_interface_error_);
+}
+
+bool NetworkClientSecure::verify(const char *fingerprint,
+                                 const char *domain_name) {
+  if (_impl->gsm_client_secure_) {
+    // Simply calling SSLClient::verify() will break TLS handshake
+    // Can be skipped as verification is done by SSLClient itself,
+    // ArduinoWebSockets need not call it
+    return true;
+  } else if (_impl->wifi_client_secure_) {
+    return _impl->wifi_client_secure_->verify(fingerprint, domain_name);
+  }
+  Serial.println(_impl->no_interface_error_);
+  return false;
+}

--- a/examples/esp32_pio/CustomNetworkClient/src/network_client_secure.cpp
+++ b/examples/esp32_pio/CustomNetworkClient/src/network_client_secure.cpp
@@ -1,14 +1,15 @@
 #include "network_client_impl.h"
 
-NetworkClientSecure::NetworkClientSecure() {}
-NetworkClientSecure::NetworkClientSecure(WiFiClient wifi_client) {}
-NetworkClientSecure::~NetworkClientSecure() {
+WebSocketsNetworkClientSecure::WebSocketsNetworkClientSecure() {}
+WebSocketsNetworkClientSecure::WebSocketsNetworkClientSecure(
+    WiFiClient wifi_client) {}
+WebSocketsNetworkClientSecure::~WebSocketsNetworkClientSecure() {
   if (_impl->gsm_client_secure_) {
     _impl->gsm_client_secure_->stop();
   }
 }
 
-int NetworkClientSecure::connect(IPAddress ip, uint16_t port) {
+int WebSocketsNetworkClientSecure::connect(IPAddress ip, uint16_t port) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->connect(ip, port);
   } else if (_impl->wifi_client_secure_) {
@@ -18,7 +19,7 @@ int NetworkClientSecure::connect(IPAddress ip, uint16_t port) {
   return 0;
 }
 
-int NetworkClientSecure::connect(const char *host, uint16_t port) {
+int WebSocketsNetworkClientSecure::connect(const char *host, uint16_t port) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->connect(host, port);
   } else if (_impl->wifi_client_secure_) {
@@ -27,8 +28,8 @@ int NetworkClientSecure::connect(const char *host, uint16_t port) {
   Serial.println(_impl->no_interface_error_);
   return 0;
 }
-int NetworkClientSecure::connect(const char *host, uint16_t port,
-                                 int32_t timeout_ms) {
+int WebSocketsNetworkClientSecure::connect(const char *host, uint16_t port,
+                                           int32_t timeout_ms) {
   if (_impl->gsm_client_secure_) {
     // Ignore timeout as will cause read() to block for specified time
     return _impl->gsm_client_secure_->connect(host, port);
@@ -39,7 +40,7 @@ int NetworkClientSecure::connect(const char *host, uint16_t port,
   return 0;
 }
 
-size_t NetworkClientSecure::write(uint8_t data) {
+size_t WebSocketsNetworkClientSecure::write(uint8_t data) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->write(data);
   } else if (_impl->wifi_client_secure_) {
@@ -49,7 +50,7 @@ size_t NetworkClientSecure::write(uint8_t data) {
   return 0;
 }
 
-size_t NetworkClientSecure::write(const uint8_t *buf, size_t size) {
+size_t WebSocketsNetworkClientSecure::write(const uint8_t *buf, size_t size) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->write(buf, size);
   } else if (_impl->wifi_client_secure_) {
@@ -59,7 +60,7 @@ size_t NetworkClientSecure::write(const uint8_t *buf, size_t size) {
   return 0;
 }
 
-size_t NetworkClientSecure::write(const char *str) {
+size_t WebSocketsNetworkClientSecure::write(const char *str) {
   const int size = strlen(str);
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->write((const uint8_t *)str, size);
@@ -70,7 +71,7 @@ size_t NetworkClientSecure::write(const char *str) {
   return 0;
 }
 
-int NetworkClientSecure::available() {
+int WebSocketsNetworkClientSecure::available() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->available();
   } else if (_impl->wifi_client_secure_) {
@@ -80,7 +81,7 @@ int NetworkClientSecure::available() {
   return 0;
 }
 
-int NetworkClientSecure::read() {
+int WebSocketsNetworkClientSecure::read() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->read();
   } else if (_impl->wifi_client_secure_) {
@@ -90,7 +91,7 @@ int NetworkClientSecure::read() {
   return 0;
 }
 
-int NetworkClientSecure::read(uint8_t *buf, size_t size) {
+int WebSocketsNetworkClientSecure::read(uint8_t *buf, size_t size) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->read(buf, size);
   } else if (_impl->wifi_client_secure_) {
@@ -100,7 +101,7 @@ int NetworkClientSecure::read(uint8_t *buf, size_t size) {
   return 0;
 }
 
-int NetworkClientSecure::peek() {
+int WebSocketsNetworkClientSecure::peek() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->peek();
   } else if (_impl->wifi_client_secure_) {
@@ -110,7 +111,7 @@ int NetworkClientSecure::peek() {
   return 0;
 }
 
-void NetworkClientSecure::flush() {
+void WebSocketsNetworkClientSecure::flush() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->flush();
   } else if (_impl->wifi_client_secure_) {
@@ -119,7 +120,7 @@ void NetworkClientSecure::flush() {
   Serial.println(_impl->no_interface_error_);
 }
 
-void NetworkClientSecure::stop() {
+void WebSocketsNetworkClientSecure::stop() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->stop();
   } else if (_impl->wifi_client_secure_) {
@@ -128,7 +129,7 @@ void NetworkClientSecure::stop() {
   Serial.println(_impl->no_interface_error_);
 }
 
-uint8_t NetworkClientSecure::connected() {
+uint8_t WebSocketsNetworkClientSecure::connected() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->connected();
   } else if (_impl->wifi_client_secure_) {
@@ -138,7 +139,7 @@ uint8_t NetworkClientSecure::connected() {
   return 0;
 }
 
-NetworkClientSecure::operator bool() {
+WebSocketsNetworkClientSecure::operator bool() {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->operator bool();
   } else if (_impl->wifi_client_secure_) {
@@ -148,7 +149,7 @@ NetworkClientSecure::operator bool() {
   return 0;
 }
 
-void NetworkClientSecure::setCACert(const char *rootCA) {
+void WebSocketsNetworkClientSecure::setCACert(const char *rootCA) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->setCertificate(rootCA);
   } else if (_impl->wifi_client_secure_) {
@@ -157,7 +158,7 @@ void NetworkClientSecure::setCACert(const char *rootCA) {
   Serial.println(_impl->no_interface_error_);
 }
 
-void NetworkClientSecure::setCACertBundle(const uint8_t *bundle) {
+void WebSocketsNetworkClientSecure::setCACertBundle(const uint8_t *bundle) {
   if (_impl->gsm_client_secure_) {
     return _impl->gsm_client_secure_->setCACertBundle(bundle);
   } else if (_impl->wifi_client_secure_) {
@@ -166,7 +167,7 @@ void NetworkClientSecure::setCACertBundle(const uint8_t *bundle) {
   Serial.println(_impl->no_interface_error_);
 }
 
-void NetworkClientSecure::setInsecure() {
+void WebSocketsNetworkClientSecure::setInsecure() {
   if (_impl->gsm_client_secure_) {
     _impl->gsm_client_secure_->setInsecure();
   } else if (_impl->wifi_client_secure_) {
@@ -175,8 +176,8 @@ void NetworkClientSecure::setInsecure() {
   Serial.println(_impl->no_interface_error_);
 }
 
-bool NetworkClientSecure::verify(const char *fingerprint,
-                                 const char *domain_name) {
+bool WebSocketsNetworkClientSecure::verify(const char *fingerprint,
+                                           const char *domain_name) {
   if (_impl->gsm_client_secure_) {
     // Simply calling SSLClient::verify() will break TLS handshake
     // Can be skipped as verification is done by SSLClient itself,

--- a/src/NetworkClient.h
+++ b/src/NetworkClient.h
@@ -4,31 +4,26 @@
 #include <WiFiClient.h>
 
 class NetworkClient : public Client {
-    class Impl;
+  public:
+    struct Impl;
     std::unique_ptr<Impl> _impl;
 
-  public:
     NetworkClient();
     NetworkClient(WiFiClient wifi_client);
     virtual ~NetworkClient();
 
-    int connect(IPAddress ip, uint16_t port) final;
-    int connect(const char * host, uint16_t port) final;
-    int connect(const char * host, uint16_t port, int32_t timeout);
-    size_t write(uint8_t) final;
-    size_t write(const uint8_t * buf, size_t size) final;
-    size_t write(const char * str);
-    int available() final;
-    int read() final;
-    int read(uint8_t * buf, size_t size) final;
-    int peek() final;
-    void flush() final;
-    void stop() final;
-    uint8_t connected() final;
-    operator bool() final;
-
-    void setCACert(const char * rootCA);
-    void setCACertBundle(const uint8_t * bundle);
-    void setInsecure();
-    bool verify(const char * fingerprint, const char * domain_name);
+    virtual int connect(IPAddress ip, uint16_t port);
+    virtual int connect(const char * host, uint16_t port);
+    virtual int connect(const char * host, uint16_t port, int32_t timeout);
+    virtual size_t write(uint8_t);
+    virtual size_t write(const uint8_t * buf, size_t size);
+    virtual size_t write(const char * str);
+    virtual int available();
+    virtual int read();
+    virtual int read(uint8_t * buf, size_t size);
+    virtual int peek();
+    virtual void flush();
+    virtual void stop();
+    virtual uint8_t connected();
+    virtual operator bool();
 };

--- a/src/NetworkClient.h
+++ b/src/NetworkClient.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Client.h>
+#include <WiFiClient.h>
+
+class NetworkClient : public Client {
+  public:
+    NetworkClient();
+    NetworkClient(WiFiClient wifi_client);
+    virtual ~NetworkClient() = default;
+
+    int connect(IPAddress ip, uint16_t port) final;
+    int connect(const char * host, uint16_t port) final;
+    int connect(const char * host, uint16_t port, int32_t timeout);
+    size_t write(uint8_t) final;
+    size_t write(const uint8_t * buf, size_t size) final;
+    size_t write(const char * str);
+    int available() final;
+    int read() final;
+    int read(uint8_t * buf, size_t size) final;
+    int peek() final;
+    void flush() final;
+    void stop() final;
+    uint8_t connected() final;
+    operator bool() final;
+
+    void setCACert(const char * rootCA);
+    void setCACertBundle(const uint8_t * bundle);
+    void setInsecure();
+    bool verify(const char * fingerprint, const char * domain_name);
+};

--- a/src/NetworkClient.h
+++ b/src/NetworkClient.h
@@ -4,10 +4,13 @@
 #include <WiFiClient.h>
 
 class NetworkClient : public Client {
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+
   public:
     NetworkClient();
     NetworkClient(WiFiClient wifi_client);
-    virtual ~NetworkClient() = default;
+    virtual ~NetworkClient();
 
     int connect(IPAddress ip, uint16_t port) final;
     int connect(const char * host, uint16_t port) final;

--- a/src/NetworkClientSecure.h
+++ b/src/NetworkClientSecure.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <NetworkClient.h>
+
+class NetworkClientSecure : public NetworkClient {
+  public:
+    NetworkClientSecure();
+    NetworkClientSecure(WiFiClient wifi_client);
+    virtual ~NetworkClientSecure();
+
+    int connect(IPAddress ip, uint16_t port) override;
+    int connect(const char * host, uint16_t port) override;
+    int connect(const char * host, uint16_t port, int32_t timeout) override;
+    size_t write(uint8_t) override;
+    size_t write(const uint8_t * buf, size_t size) override;
+    size_t write(const char * str) override;
+    int available() override;
+    int read() override;
+    int read(uint8_t * buf, size_t size) override;
+    int peek() override;
+    void flush() override;
+    void stop() override;
+    uint8_t connected() override;
+    operator bool() override;
+
+    void setCACert(const char * rootCA);
+    void setCACertBundle(const uint8_t * bundle);
+    void setInsecure();
+    bool verify(const char * fingerprint, const char * domain_name);
+};

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -287,7 +287,15 @@
 #define WEBSOCKETS_NETWORK_CLASS WiFiClient
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
 
-#elif(WEBSOCKETS_NETWORK_TYPE != NETWORK_CUSTOM)
+#elif(WEBSOCKETS_NETWORK_TYPE == NETWORK_CUSTOM)
+#include <NetworkClient.h>
+#include <WiFiServer.h>
+
+#define SSL_AXTLS
+#define WEBSOCKETS_NETWORK_CLASS NetworkClient
+#define WEBSOCKETS_NETWORK_SSL_CLASS NetworkClient
+#define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
+#else
 #error "no network type selected!"
 #endif
 

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -135,6 +135,7 @@
 #define NETWORK_UNOWIFIR4 (7)
 #define NETWORK_WIFI_NINA (8)
 #define NETWORK_SAMD_SEED (9)
+#define NETWORK_CUSTOM (10)
 
 // max size of the WS Message Header
 #define WEBSOCKETS_MAX_HEADER_SIZE (14)
@@ -286,7 +287,7 @@
 #define WEBSOCKETS_NETWORK_CLASS WiFiClient
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
 
-#else
+#elif(WEBSOCKETS_NETWORK_TYPE != NETWORK_CUSTOM)
 #error "no network type selected!"
 #endif
 

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -288,12 +288,12 @@
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
 
 #elif(WEBSOCKETS_NETWORK_TYPE == NETWORK_CUSTOM)
-#include <NetworkClient.h>
+#include <NetworkClientSecure.h>
 #include <WiFiServer.h>
 
 #define SSL_AXTLS
 #define WEBSOCKETS_NETWORK_CLASS NetworkClient
-#define WEBSOCKETS_NETWORK_SSL_CLASS NetworkClient
+#define WEBSOCKETS_NETWORK_SSL_CLASS NetworkClientSecure
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
 #else
 #error "no network type selected!"
@@ -377,7 +377,7 @@ typedef struct {
 
 #if defined(HAS_SSL)
     bool isSSL = false;    ///< run in ssl mode
-    WEBSOCKETS_NETWORK_SSL_CLASS * ssl;
+    WEBSOCKETS_NETWORK_SSL_CLASS * ssl = nullptr;
 #endif
 
     String cUrl;           ///< http url

--- a/src/WebSockets.h
+++ b/src/WebSockets.h
@@ -288,12 +288,12 @@
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
 
 #elif(WEBSOCKETS_NETWORK_TYPE == NETWORK_CUSTOM)
-#include <NetworkClientSecure.h>
+#include <WebSocketsNetworkClientSecure.h>
 #include <WiFiServer.h>
 
 #define SSL_AXTLS
-#define WEBSOCKETS_NETWORK_CLASS NetworkClient
-#define WEBSOCKETS_NETWORK_SSL_CLASS NetworkClientSecure
+#define WEBSOCKETS_NETWORK_CLASS WebSocketsNetworkClient
+#define WEBSOCKETS_NETWORK_SSL_CLASS WebSocketsNetworkClientSecure
 #define WEBSOCKETS_NETWORK_SERVER_CLASS WiFiServer
 #else
 #error "no network type selected!"

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -556,6 +556,7 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client) {
 #endif
 #endif
         client->tcp = NULL;
+        client->ssl = NULL;
     }
 
     client->cCode        = 0;

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -525,7 +525,7 @@ void WebSocketsClient::messageReceived(WSclient_t * client, WSopcode_t opcode, u
 void WebSocketsClient::clientDisconnect(WSclient_t * client) {
     bool event = false;
 
-#if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_RP2040)
+#if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_RP2040) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_CUSTOM)
     if(client->isSSL && client->ssl) {
         if(client->ssl->connected()) {
             client->ssl->flush();
@@ -556,7 +556,6 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client) {
 #endif
 #endif
         client->tcp = NULL;
-        client->ssl = NULL;
     }
 
     client->cCode        = 0;

--- a/src/WebSocketsNetworkClient.h
+++ b/src/WebSocketsNetworkClient.h
@@ -3,14 +3,14 @@
 #include <Client.h>
 #include <WiFiClient.h>
 
-class NetworkClient : public Client {
+class WebSocketsNetworkClient : public Client {
   public:
     struct Impl;
     std::unique_ptr<Impl> _impl;
 
-    NetworkClient();
-    NetworkClient(WiFiClient wifi_client);
-    virtual ~NetworkClient();
+    WebSocketsNetworkClient();
+    WebSocketsNetworkClient(WiFiClient wifi_client);
+    virtual ~WebSocketsNetworkClient();
 
     virtual int connect(IPAddress ip, uint16_t port);
     virtual int connect(const char * host, uint16_t port);

--- a/src/WebSocketsNetworkClientSecure.h
+++ b/src/WebSocketsNetworkClientSecure.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <NetworkClient.h>
+#include <WebSocketsNetworkClient.h>
 
-class NetworkClientSecure : public NetworkClient {
+class WebSocketsNetworkClientSecure : public WebSocketsNetworkClient {
   public:
-    NetworkClientSecure();
-    NetworkClientSecure(WiFiClient wifi_client);
-    virtual ~NetworkClientSecure();
+    WebSocketsNetworkClientSecure();
+    WebSocketsNetworkClientSecure(WiFiClient wifi_client);
+    virtual ~WebSocketsNetworkClientSecure();
 
     int connect(IPAddress ip, uint16_t port) override;
     int connect(const char * host, uint16_t port) override;


### PR DESCRIPTION
Why:

- Allow user-defined network interfaces to switch been WiFi and mobile modems during run-time
- Allow custom classes to be used as the network, ssl and server classes

This change addresses the need by:

- Creating a new custom WEBSOCKETS_NETWORK_TYPE that expects the user to set network classes
  - WEBSOCKETS_NETWORK_CLASS
  - WEBSOCKETS_NETWORK_SSL_CLASS
  - WEBSOCKETS_NETWORK_SERVER_CLASS

Related issues: #779 #910