### PR TITLE
changed from deprecated flush() to clear()

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -528,7 +528,7 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client) {
 #ifdef HAS_SSL
     if(client->isSSL && client->ssl) {
         if(client->ssl->connected()) {
-            client->ssl->flush();
+            client->ssl->clear();
             client->ssl->stop();
         }
         event = true;
@@ -541,7 +541,7 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client) {
     if(client->tcp) {
         if(client->tcp->connected()) {
 #if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
-            client->tcp->flush();
+            client->tcp->clear();
 #endif
             client->tcp->stop();
         }
@@ -1029,3 +1029,4 @@ void WebSocketsClient::enableHeartbeat(uint32_t pingInterval, uint32_t pongTimeo
 void WebSocketsClient::disableHeartbeat() {
     _client.pingInterval = 0;
 }
+

--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -547,7 +547,7 @@ void WebSocketsServerCore::dropNativeClient(WSclient_t * client) {
     if(client->tcp) {
         if(client->tcp->connected()) {
 #if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP32) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_RP2040)
-            client->tcp->flush();
+            client->tcp->clear();
 #endif
             client->tcp->stop();
         }
@@ -570,7 +570,7 @@ void WebSocketsServerCore::clientDisconnect(WSclient_t * client) {
 #if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_RP2040)
     if(client->isSSL && client->ssl) {
         if(client->ssl->connected()) {
-            client->ssl->flush();
+            client->ssl->clear();
             client->ssl->stop();
         }
         delete client->ssl;
@@ -986,3 +986,4 @@ void WebSocketsServer::loop(void) {
     }
 }
 #endif
+


### PR DESCRIPTION
'virtual void NetworkClient::flush()' is deprecated: Use clear() instead. [-Wdeprecated-declarations]