### PR TITLE
Add beginSslWithClientKey

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -128,6 +128,12 @@ void WebSocketsClient::beginSslWithCA(const char * host, uint16_t port, const ch
     _CA_bundle    = NULL;
 }
 
+void WebSocketsClient::beginSslWithClientKey(const char * host, uint16_t port, const char * url, const char * CA_cert, const char * clientCert, const char * clientPrivateKey, const char * protocol) {
+    _client_cert = clientCert;
+    _client_key  = clientPrivateKey;
+    beginSslWithCA(host, port, url, CA_cert, protocol);
+}
+
 #if defined(ESP32) && ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 4)
 void WebSocketsClient::beginSslWithBundle(const char * host, uint16_t port, const char * url, const uint8_t * CA_bundle, size_t CA_bundle_size, const char * protocol) {
     begin(host, port, url, protocol);
@@ -256,8 +262,15 @@ void WebSocketsClient::loop(void) {
             _client.ssl = new WEBSOCKETS_NETWORK_SSL_CLASS();
             _client.tcp = _client.ssl;
             if(_CA_cert) {
-                DEBUG_WEBSOCKETS("[WS-Client] setting CA certificate");
+                DEBUG_WEBSOCKETS("[WS-Client] setting CA certificate\n");
 #if defined(ESP32)
+                if(_client_cert && _client_key) {
+                    DEBUG_WEBSOCKETS("[WS-Client] setting client certificate and private key\n");
+                    _client.ssl->setCertificate(_client_cert);
+                    _client.ssl->setPrivateKey(_client_key);
+                } else {
+                    DEBUG_WEBSOCKETS("[WS-Client] no client certificate and/or private key set\n");
+                }
                 _client.ssl->setCACert(_CA_cert);
 #elif defined(ESP8266) && defined(SSL_AXTLS)
                 _client.ssl->setCACert((const uint8_t *)_CA_cert, strlen(_CA_cert) + 1);
@@ -272,7 +285,7 @@ void WebSocketsClient::loop(void) {
 #endif
 #if defined(ESP32)
             } else if(_CA_bundle) {
-                DEBUG_WEBSOCKETS("[WS-Client] setting CA bundle");
+                DEBUG_WEBSOCKETS("[WS-Client] setting CA bundle\n");
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 4)
                 _client.ssl->setCACertBundle(_CA_bundle, _CA_bundle_size);
 #else
@@ -287,8 +300,10 @@ void WebSocketsClient::loop(void) {
                 _client.ssl->setInsecure();
             }
             if(_client_cert && _client_key) {
+                DEBUG_WEBSOCKETS("[WS-Client] setting client certificate and private key\n");
                 _client.ssl->setClientRSACert(_client_cert, _client_key);
-                DEBUG_WEBSOCKETS("[WS-Client] setting client certificate and key");
+            } else {
+                DEBUG_WEBSOCKETS("[WS-Client] no client certificate and/or private key set\n");
 #endif
             }
         } else {

--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -55,6 +55,7 @@ class WebSocketsClient : protected WebSockets {
     void setSSLClientCertKey(const char * clientCert = NULL, const char * clientPrivateKey = NULL);
 #endif
     void beginSslWithCA(const char * host, uint16_t port, const char * url = "/", const char * CA_cert = NULL, const char * protocol = "arduino");
+    void beginSslWithClientKey(const char * host, uint16_t port, const char * url, const char * CA_cert, const char * clientCert, const char * clientPrivateKey, const char * protocol = "arduino");
 #ifdef ESP32
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 4)
     void beginSslWithBundle(const char * host, uint16_t port, const char * url = "/", const uint8_t * CA_bundle = NULL, size_t CA_bundle_size = 0, const char * protocol = "arduino");
@@ -122,6 +123,8 @@ class WebSocketsClient : protected WebSockets {
     String _fingerprint;
     const char * _CA_cert;
     const uint8_t * _CA_bundle;
+    const char * _client_cert;
+    const char * _client_key;
 #if defined(ESP32)
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 4)
     size_t _CA_bundle_size;


### PR DESCRIPTION
Not sure if this is the exact place to put it, in between the gates, but we really need this feature, just let me know where you want it placed.

It is tested and it works great.

Thank you for your work!

PS: related to the discussion in #921

This works using: https://github.com/espressif/arduino-esp32/blob/0dbaa3f0f7ff8c7f7c303fe33555e8cf548acae8/libraries/NetworkClientSecure/src/NetworkClientSecure.cpp#L355-L369