### PR TITLE
add client disconnect reason text in events

### DIFF
--- a/src/WebSocketsClient.h
+++ b/src/WebSocketsClient.h
@@ -157,7 +157,10 @@ class WebSocketsClient : protected WebSockets {
 
     void messageReceived(WSclient_t * client, WSopcode_t opcode, uint8_t * payload, size_t length, bool fin);
 
-    void clientDisconnect(WSclient_t * client);
+    void clientDisconnect(WSclient_t * client) {
+        clientDisconnect(client, NULL);
+    }
+    void clientDisconnect(WSclient_t * client, const char * reason = NULL);
     bool clientIsConnected(WSclient_t * client);
 
 #if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)


### PR DESCRIPTION
This helps as well to display the reason on libs that link logging based on Events only.

https://github.com/matth-x/MicroOcpp/blob/0455ec05aabdb3475cbd2dedee430acc51b155c7/src/MicroOcpp/Core/Connection.cpp#L71-L75