### PR TITLE
Enable ssl verification for axtls

### DIFF
--- a/src/SocketIOclient.cpp
+++ b/src/SocketIOclient.cpp
@@ -38,13 +38,13 @@ void SocketIOclient::beginSSL(String host, uint16_t port, String url, String pro
     WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
-#if defined(SSL_BARESSL)
 void SocketIOclient::beginSSLWithCA(const char * host, uint16_t port, const char * url, const char * CA_cert, const char * protocol, uint32_t pingInterval, uint32_t pongTimeout, uint8_t disconnectTimeoutCount) {
     WebSocketsClient::beginSocketIOSSLWithCA(host, port, url, CA_cert, protocol);
     WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);
     initClient();
 }
 
+#if defined(SSL_BARESSL)
 void SocketIOclient::beginSSLWithCA(const char * host, uint16_t port, const char * url, BearSSL::X509List * CA_cert, const char * protocol, uint32_t pingInterval, uint32_t pongTimeout, uint8_t disconnectTimeoutCount) {
     WebSocketsClient::beginSocketIOSSLWithCA(host, port, url, CA_cert, protocol);
     WebSocketsClient::enableHeartbeat(pingInterval, pongTimeout, disconnectTimeoutCount);

--- a/src/SocketIOclient.h
+++ b/src/SocketIOclient.h
@@ -53,8 +53,8 @@ class SocketIOclient : protected WebSocketsClient {
 #ifdef HAS_SSL
     void beginSSL(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
     void beginSSL(String host, uint16_t port, String url = "/socket.io/?EIO=3", String protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
-#ifndef SSL_AXTLS
     void beginSSLWithCA(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", const char * CA_cert = NULL, const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);
+#ifndef SSL_AXTLS
     void setSSLClientCertKey(const char * clientCert = NULL, const char * clientPrivateKey = NULL);
 #if defined(SSL_BARESSL)
     void beginSSLWithCA(const char * host, uint16_t port, const char * url = "/socket.io/?EIO=3", BearSSL::X509List * CA_cert = NULL, const char * protocol = "arduino", uint32_t pingInterval = 60 * 1000, uint32_t pongTimeout = 90 * 1000, uint8_t disconnectTimeoutCount = 5);


### PR DESCRIPTION
In the `WebSocketsClient.{h,cpp}` the `beginSocketIOSSLWithCA` is always available when `HAS_SSL` is defined. This PR also allows to use this in the `SocketIOclient`.