### PR TITLE
Remove compiler warning

### DIFF
--- a/src/WebSockets.cpp
+++ b/src/WebSockets.cpp
@@ -750,7 +750,7 @@ void WebSockets::handleHBTimeout(WSclient_t * client) {
                 client->pongTimeoutCount++;
                 client->lastPing = millis() - client->pingInterval - 500;    // force ping on the next run
 
-                DEBUG_WEBSOCKETS("[HBtimeout] pong TIMEOUT! lp=%d millis=%lu pi=%d count=%d\n", client->lastPing, millis(), pi, client->pongTimeoutCount);
+                DEBUG_WEBSOCKETS("[HBtimeout] pong TIMEOUT! lp=%ld millis=%lu pi=%ld count=%d\n", client->lastPing, millis(), pi, client->pongTimeoutCount);
 
                 if(client->disconnectTimeoutCount && client->pongTimeoutCount >= client->disconnectTimeoutCount) {
                     DEBUG_WEBSOCKETS("[HBtimeout] count=%d, DISCONNECTING\n", client->pongTimeoutCount);
@@ -760,3 +760,4 @@ void WebSockets::handleHBTimeout(WSclient_t * client) {
         }
     }
 }
+


### PR DESCRIPTION
With actual 2.7.3 a unnecessary compiler warning occurs.

<img width="1507" height="901" alt="grafik" src="https://github.com/user-attachments/assets/eb86b300-1427-4516-b853-23380940110d" />

See fix povided!