### PR TITLE
Avoid ESP32 client flush deprecation warning

### DIFF
--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -569,7 +569,7 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client, const char * reason
 
     if(client->tcp) {
         if(client->tcp->connected()) {
-#if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
+#if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP32) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_RP2040)
             client->tcp->flush();
 #endif
             client->tcp->stop();

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -570,8 +570,12 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client, const char * reason
     if(client->tcp) {
         if(client->tcp->connected()) {
 #if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
-#if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) && defined(ESP_ARDUINO_VERSION) && ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+#if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) && defined(ESP_ARDUINO_VERSION) && defined(ESP_ARDUINO_VERSION_VAL)
+#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
             client->tcp->clear();
+#else
+            client->tcp->flush();
+#endif
 #else
             client->tcp->flush();
 #endif

--- a/src/WebSocketsClient.cpp
+++ b/src/WebSocketsClient.cpp
@@ -569,8 +569,12 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client, const char * reason
 
     if(client->tcp) {
         if(client->tcp->connected()) {
-#if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP32) && (WEBSOCKETS_NETWORK_TYPE != NETWORK_RP2040)
+#if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
+#if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32) && defined(ESP_ARDUINO_VERSION) && ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+            client->tcp->clear();
+#else
             client->tcp->flush();
+#endif
 #endif
             client->tcp->stop();
         }


### PR DESCRIPTION
## Summary
- skip the client-side `flush()` call for ESP32/RP2040 before disconnecting
- match the existing server-side guard that already avoids `flush()` on those network types

## Why
Fixes #974. ESP32 Arduino core reports `NetworkClient::flush()` as deprecated in this path. Using the same guard as the server path avoids the warning without switching to `clear()` on network clients that may not expose it.

## Validation
- `git -c core.whitespace=cr-at-eol diff --check`

I did not run an Arduino/PlatformIO compile locally.